### PR TITLE
change layout; group done tasks

### DIFF
--- a/calcit.edn
+++ b/calcit.edn
@@ -2214,15 +2214,15 @@
                 :type :expr, :by "root", :at 1521045553893, :id "rylcNxR8KG"
                 :data {
                  "T" {:type :leaf, :by "root", :at 1521132750289, :text "str", :id "rylcNxR8KGleaf"}
-                 "j" {:type :leaf, :by "root", :at 1521132731103, :text "|Done Tasks(", :id "BJfhNxCLKz"}
+                 "j" {:type :leaf, :by "root", :at 1531643563714, :text "|Done Tasks(", :id "BJfhNxCLKz"}
                  "n" {
-                  :type :expr, :by "root", :at 1521132733096, :id "S1gH6Vm_tM"
+                  :type :expr, :by "root", :at 1531643568035, :id "SJOh8Y_7Q"
                   :data {
-                   "T" {:type :leaf, :by "root", :at 1521132733980, :text "count", :id "B1S64QdFG"}
-                   "j" {:type :leaf, :by "root", :at 1521132736106, :text "router-data", :id "Hk7L6VQ_YM"}
+                   "T" {:type :leaf, :by "root", :at 1531643568693, :text "count", :id "r1P2LYuQX"}
+                   "j" {:type :leaf, :by "root", :at 1531643569494, :text "tasks", :id "BJbY2IYOX7"}
                   }
                  }
-                 "r" {:type :leaf, :by "root", :at 1521132731928, :text "|)", :id "ryx7p4XdtG"}
+                 "r" {:type :leaf, :by "root", :at 1531643566177, :text "\")", :id "rkgN3IYuQm"}
                 }
                }
                "j" {

--- a/calcit.edn
+++ b/calcit.edn
@@ -2838,6 +2838,37 @@
                               :data {
                                "T" {:type :leaf, :by "root", :at 1521045635219, :text "->>", :id "Hye9Yg0IKG"}
                                "j" {:type :leaf, :by "root", :at 1524383273083, :text "tasks", :id "BJ2KeCUFf"}
+                               "n" {
+                                :type :expr, :by "root", :at 1531643301089, :id "HylasSFOmQ"
+                                :data {
+                                 "T" {:type :leaf, :by "root", :at 1531643307955, :text "sort-by", :id "HkpsHYOQ7"}
+                                 "j" {
+                                  :type :expr, :by "root", :at 1531643316211, :id "BJxn3SFOQ7"
+                                  :data {
+                                   "T" {:type :leaf, :by "root", :at 1531643316591, :text "fn", :id "SJ3hrtOmm"}
+                                   "j" {
+                                    :type :expr, :by "root", :at 1531643318704, :id "BJ1arKumQ"
+                                    :data {
+                                     "T" {:type :leaf, :by "root", :at 1531643326884, :text "task", :id "rJzIpSY_mX"}
+                                    }
+                                   }
+                                   "r" {
+                                    :type :expr, :by "root", :at 1531643335875, :id "S1xCSFuQ7"
+                                    :data {
+                                     "D" {:type :leaf, :by "root", :at 1531643352154, :text "unchecked-negate", :id "HkegCHKdXm"}
+                                     "T" {
+                                      :type :expr, :by "root", :at 1531643328882, :id "H1t6rtO7X"
+                                      :data {
+                                       "T" {:type :leaf, :by "root", :at 1531643330804, :text ":time", :id "H1t6rtO7Xleaf"}
+                                       "j" {:type :leaf, :by "root", :at 1531643331320, :text "task", :id "HJbopHFuXm"}
+                                      }
+                                     }
+                                    }
+                                   }
+                                  }
+                                 }
+                                }
+                               }
                                "r" {
                                 :type :expr, :by "root", :at 1521045639284, :id "SyNkqgRUtz"
                                 :data {

--- a/calcit.edn
+++ b/calcit.edn
@@ -1652,6 +1652,7 @@
             "yj" {:type :leaf, :by "root", :at 1521044613397, :text "action->", :id "rkgstnpLYG"}
             "yr" {:type :leaf, :by "root", :at 1521044740074, :text "input", :id "SJeoWaaItG"}
             "yv" {:type :leaf, :by "root", :at 1530033383090, :text "a", :id "BklylHggzm"}
+            "yx" {:type :leaf, :by "root", :at 1531641984803, :text "pre", :id "BkOKgFOmQ"}
            }
           }
          }
@@ -1732,18 +1733,12 @@
          }
         }
         "yyj" {
-         :type :expr, :by "root", :at 1524383109418, :id "BklTta3FhM"
+         :type :expr, :by "root", :at 1531643021557, :id "SkL9Etdmm"
          :data {
-          "T" {:type :leaf, :by "root", :at 1524383109773, :text "[]", :id "BklTta3FhMleaf"}
-          "b" {:type :leaf, :by "root", :at 1524383117589, :text "app.util", :id "Sym9anYhz"}
-          "j" {:type :leaf, :by "root", :at 1524383111569, :text ":refer", :id "Bk-0F63thG"}
-          "r" {
-           :type :expr, :by "root", :at 1524383112541, :id "SyWc6ht2f"
-           :data {
-            "T" {:type :leaf, :by "root", :at 1524383112184, :text "[]", :id "Hyle9Tht3G"}
-            "j" {:type :leaf, :by "root", :at 1524383113064, :text "format-date", :id "Skg-9Tht3f"}
-           }
-          }
+          "T" {:type :leaf, :by "root", :at 1531643022550, :text "[]", :id "SkL9Etdmmleaf"}
+          "j" {:type :leaf, :by "root", :at 1531643024369, :text "\"dayjs", :id "B1lvqNt_mm"}
+          "r" {:type :leaf, :by "root", :at 1531643025096, :text ":as", :id "r1Mu9EYOQX"}
+          "v" {:type :leaf, :by "root", :at 1531643025971, :text "dayjs", :id "SJGK94FdQQ"}
          }
         }
        }
@@ -2117,6 +2112,45 @@
              }
             }
            }
+           "j" {
+            :type :expr, :by "root", :at 1531642768209, :id "Hyxuc7YOXm"
+            :data {
+             "T" {:type :leaf, :by "root", :at 1531642771260, :text "cursor", :id "Hyxuc7YOXmleaf"}
+             "j" {
+              :type :expr, :by "root", :at 1531642773095, :id "rJpqmFuQX"
+              :data {
+               "T" {:type :leaf, :by "root", :at 1531642777227, :text ":cursor", :id "ByncQYu7m"}
+               "j" {:type :leaf, :by "root", :at 1531642778826, :text "router-data", :id "Syr-jQFdm7"}
+              }
+             }
+            }
+           }
+           "r" {
+            :type :expr, :by "root", :at 1531642779733, :id "ryVoQFumQ"
+            :data {
+             "T" {:type :leaf, :by "root", :at 1531642781287, :text "months", :id "ryVoQFumQleaf"}
+             "j" {
+              :type :expr, :by "root", :at 1531642782107, :id "H1xUsQYOmX"
+              :data {
+               "T" {:type :leaf, :by "root", :at 1531642783749, :text ":months", :id "rkLimY_m7"}
+               "j" {:type :leaf, :by "root", :at 1531642786022, :text "router-data", :id "ryZds7tOXm"}
+              }
+             }
+            }
+           }
+           "v" {
+            :type :expr, :by "root", :at 1531642803823, :id "rkgnhmF_Qm"
+            :data {
+             "T" {:type :leaf, :by "root", :at 1531642804556, :text "tasks", :id "rkgnhmF_Qmleaf"}
+             "j" {
+              :type :expr, :by "root", :at 1531642805225, :id "ByZTnQYuQm"
+              :data {
+               "T" {:type :leaf, :by "root", :at 1531642808530, :text ":tasks", :id "Syga2mtumQ"}
+               "j" {:type :leaf, :by "root", :at 1531642806751, :text "router-data", :id "SJ4Ah7Y_Xm"}
+              }
+             }
+            }
+           }
           }
          }
          "T" {
@@ -2338,45 +2372,218 @@
             }
            }
            "v" {
-            :type :expr, :by "root", :at 1524383219785, :id "rk3g03K3f"
+            :type :expr, :by "root", :at 1531642530659, :id "rJjofKuX7"
             :data {
-             "D" {:type :leaf, :by "root", :at 1524383220461, :text "let", :id "SJx2g0hKnM"}
+             "D" {:type :leaf, :by "root", :at 1531642531464, :text "div", :id "B1gssfKumQ"}
              "L" {
-              :type :expr, :by "root", :at 1524383220810, :id "H1aeC3thM"
+              :type :expr, :by "root", :at 1531642531667, :id "Bke2iGFum7"
               :data {
-               "T" {
-                :type :expr, :by "root", :at 1524383220971, :id "BygTgA3KnG"
+               "T" {:type :leaf, :by "root", :at 1531642532047, :text "{}", :id "HJ3ozFumm"}
+               "j" {
+                :type :expr, :by "root", :at 1531642532583, :id "BJaofF_7Q"
                 :data {
-                 "T" {:type :leaf, :by "root", :at 1524383227199, :text "tasks-by-time", :id "ByNhxRhKhG"}
+                 "T" {:type :leaf, :by "root", :at 1531642533312, :text ":style", :id "r17hifFOmm"}
+                 "j" {:type :leaf, :by "root", :at 1531642534260, :text "ui/row", :id "By8TiGYO77"}
+                }
+               }
+              }
+             }
+             "P" {
+              :type :expr, :by "root", :at 1531642535246, :id "SyZJnfYdXQ"
+              :data {
+               "T" {:type :leaf, :by "root", :at 1531642550829, :text "list->", :id "SyZJnfYdXQleaf"}
+               "j" {
+                :type :expr, :by "root", :at 1531642551111, :id "S1z1aMFu77"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1531642552367, :text "{}", :id "SJZJpztOXQ"}
                  "j" {
-                  :type :expr, :by "root", :at 1524382730905, :id "S1gDb02Y2M"
+                  :type :expr, :by "root", :at 1531642614659, :id "Sk1Z7KuQm"
                   :data {
-                   "D" {:type :leaf, :by "root", :at 1524382734701, :text "->>", :id "rJl7Gh3tnM"}
-                   "T" {:type :leaf, :by "root", :at 1524382698999, :text "router-data", :id "HkMe3hK3f"}
-                   "j" {:type :leaf, :by "root", :at 1524382743435, :text "vals", :id "H1bwfhhKhG"}
-                   "r" {
-                    :type :expr, :by "root", :at 1524382744775, :id "HyZ7h3K3z"
+                   "D" {:type :leaf, :by "root", :at 1531642615790, :text ":style", :id "Hyx1-XtuXm"}
+                   "T" {
+                    :type :expr, :by "root", :at 1531642612097, :id "S1ZnxQK_7Q"
                     :data {
-                     "T" {:type :leaf, :by "root", :at 1524382755369, :text "group-by", :id "BJWlXnnY2M"}
-                     "j" {
-                      :type :expr, :by "root", :at 1524382763391, :id "B1bXV23K3f"
+                     "D" {:type :leaf, :by "root", :at 1531642612662, :text "{}", :id "Bkz2eQKdQ7"}
+                     "T" {
+                      :type :expr, :by "root", :at 1531642613083, :id "r1G6lXFdXQ"
                       :data {
-                       "T" {:type :leaf, :by "root", :at 1524382765141, :text "fn", :id "BJZEh2tnM"}
-                       "j" {
-                        :type :expr, :by "root", :at 1524382765831, :id "BJeI433Knz"
-                        :data {
-                         "T" {:type :leaf, :by "root", :at 1524382768723, :text "task", :id "B1I4n3FhM"}
-                        }
-                       }
+                       "T" {:type :leaf, :by "root", :at 1531642606655, :text ":overflow", :id "HkxBlQtuXQ"}
+                       "j" {:type :leaf, :by "root", :at 1531642607705, :text ":auto", :id "SJWPlXF_7m"}
+                      }
+                     }
+                     "j" {
+                      :type :expr, :by "root", :at 1531642618515, :id "H1GGb7td7m"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1531642633949, :text ":font-family", :id "H1GGb7td7mleaf"}
+                       "j" {:type :leaf, :by "root", :at 1531642638221, :text "ui/font-fancy", :id "r1GfzQtumX"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "root", :at 1531642647079, :id "r1lymQtOXX"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1531642648766, :text ":max-height", :id "r1lymQtOXXleaf"}
+                       "j" {:type :leaf, :by "root", :at 1531642651402, :text "320", :id "SkfZmmtum7"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "r" {
+                :type :expr, :by "root", :at 1531642553148, :id "Skg-pftOQm"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1531642557729, :text "->>", :id "Skg-pftOQmleaf"}
+                 "f" {:type :leaf, :by "root", :at 1531642791032, :text "months", :id "By0jQYdQm"}
+                 "r" {
+                  :type :expr, :by "root", :at 1531642566612, :id "Skk0zF_77"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1531642567533, :text "map", :id "rkC6MKO7X"}
+                   "j" {
+                    :type :expr, :by "root", :at 1531642568135, :id "rJ-xRMt_QX"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1531642572530, :text "fn", :id "rJglCGtumm"}
+                     "j" {
+                      :type :expr, :by "root", :at 1531642572798, :id "rk-HCMYdm7"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1531642575563, :text "year-month", :id "HJxHRfKOm7"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "root", :at 1531642576654, :id "H1t0MFuX7"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1531642577371, :text "[]", :id "H1t0MFuX7leaf"}
+                       "j" {:type :leaf, :by "root", :at 1531642577790, :text "year-month", :id "r1MK0GK_77"}
                        "r" {
-                        :type :expr, :by "root", :at 1524382769476, :id "S1MY423Ynf"
+                        :type :expr, :by "root", :at 1531642578232, :id "S1-5CMYumX"
                         :data {
-                         "T" {:type :leaf, :by "root", :at 1524383099790, :text "format-date", :id "S1MY423Ynfleaf"}
+                         "T" {:type :leaf, :by "root", :at 1531642580991, :text "div", :id "Sk30zKuQQ"}
                          "j" {
-                          :type :expr, :by "root", :at 1524383102245, :id "B1lLtphYhG"
+                          :type :expr, :by "root", :at 1531642581213, :id "B1Xp0MYdmm"
                           :data {
-                           "T" {:type :leaf, :by "root", :at 1524383147149, :text ":time", :id "SJ8Ya3K3z"}
-                           "j" {:type :leaf, :by "root", :at 1524383107299, :text "task", :id "HyiY63Fnz"}
+                           "T" {:type :leaf, :by "root", :at 1531642581560, :text "{}", :id "HyfaRMKOmX"}
+                           "j" {
+                            :type :expr, :by "root", :at 1531642728237, :id "r1xdXt_7m"
+                            :data {
+                             "T" {:type :leaf, :by "root", :at 1531642730045, :text ":style", :id "HJxpwmKu7Q"}
+                             "j" {
+                              :type :expr, :by "root", :at 1531642736472, :id "B1dO7F_Q7"
+                              :data {
+                               "D" {:type :leaf, :by "root", :at 1531642737532, :text "merge", :id "SJF_7tdmQ"}
+                               "T" {
+                                :type :expr, :by "root", :at 1531642730352, :id "rJBG_XtO7X"
+                                :data {
+                                 "T" {:type :leaf, :by "root", :at 1531642730915, :text "{}", :id "S1NGuQFd7m"}
+                                 "j" {
+                                  :type :expr, :by "root", :at 1531642731786, :id "B1xEdXK_XX"
+                                  :data {
+                                   "T" {:type :leaf, :by "root", :at 1531642733199, :text ":cursor", :id "BkV_XKOXX"}
+                                   "j" {:type :leaf, :by "root", :at 1531642734543, :text ":pointer", :id "Bk-B_7YuXQ"}
+                                  }
+                                 }
+                                 "r" {
+                                  :type :expr, :by "root", :at 1531642917644, :id "SkA7EFO7X"
+                                  :data {
+                                   "T" {:type :leaf, :by "root", :at 1531642919347, :text ":padding", :id "SkA7EFO7Xleaf"}
+                                   "j" {:type :leaf, :by "root", :at 1531642931317, :text "\"0 18px", :id "SkmJ44KdXm"}
+                                  }
+                                 }
+                                }
+                               }
+                               "j" {
+                                :type :expr, :by "root", :at 1531642739209, :id "BJliOmYdQm"
+                                :data {
+                                 "T" {:type :leaf, :by "root", :at 1531642749577, :text "when", :id "HyWcOQYOXm"}
+                                 "j" {
+                                  :type :expr, :by "root", :at 1531642740721, :id "B1x6d7YuQm"
+                                  :data {
+                                   "D" {:type :leaf, :by "root", :at 1531642742068, :text "=", :id "B1eROQYuQX"}
+                                   "T" {:type :leaf, :by "root", :at 1531642741611, :text "cursor", :id "rkWsOQKu7m"}
+                                   "j" {:type :leaf, :by "root", :at 1531642746997, :text "year-month", :id "H1QCO7YOmQ"}
+                                  }
+                                 }
+                                 "r" {
+                                  :type :expr, :by "root", :at 1531642750372, :id "ryM8Y7KdXX"
+                                  :data {
+                                   "T" {:type :leaf, :by "root", :at 1531642751125, :text "{}", :id "ryM8Y7KdXXleaf"}
+                                   "j" {
+                                    :type :expr, :by "root", :at 1531642751637, :id "BkuFXY_Q7"
+                                    :data {
+                                     "T" {:type :leaf, :by "root", :at 1531642761808, :text ":background-color", :id "HkbPt7F_m7"}
+                                     "j" {
+                                      :type :expr, :by "root", :at 1531642934330, :id "Hk-0N4FdXX"
+                                      :data {
+                                       "T" {:type :leaf, :by "root", :at 1531642934939, :text "hsl", :id "r1Zfq7Y_XX"}
+                                       "j" {:type :leaf, :by "root", :at 1531642935673, :text "0", :id "r1GJrVYdQX"}
+                                       "r" {:type :leaf, :by "root", :at 1531642936037, :text "0", :id "rkxlB4Yumm"}
+                                       "v" {:type :leaf, :by "root", :at 1531642936454, :text "90", :id "BJMxBEt_mm"}
+                                      }
+                                     }
+                                    }
+                                   }
+                                  }
+                                 }
+                                }
+                               }
+                              }
+                             }
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "root", :at 1531642825155, :id "SklZRXY_m7"
+                            :data {
+                             "T" {:type :leaf, :by "root", :at 1531642827279, :text ":on-click", :id "SklZRXY_m7leaf"}
+                             "j" {
+                              :type :expr, :by "root", :at 1531642827571, :id "S1VCmtu7X"
+                              :data {
+                               "T" {:type :leaf, :by "root", :at 1531642828493, :text "fn", :id "ryHQ07F_mX"}
+                               "j" {
+                                :type :expr, :by "root", :at 1531642828798, :id "SkeH0XYdmX"
+                                :data {
+                                 "T" {:type :leaf, :by "root", :at 1531642829002, :text "e", :id "SkrR7KOmm"}
+                                 "j" {:type :leaf, :by "root", :at 1531642831016, :text "d!", :id "S1zSCQFd7Q"}
+                                 "r" {:type :leaf, :by "root", :at 1531642831666, :text "m!", :id "H1-w0XF_QQ"}
+                                }
+                               }
+                               "r" {
+                                :type :expr, :by "root", :at 1531642832179, :id "B1WO0QFOQ7"
+                                :data {
+                                 "T" {:type :leaf, :by "root", :at 1531642833025, :text "d!", :id "B1WO0QFOQ7leaf"}
+                                 "j" {:type :leaf, :by "root", :at 1531642835860, :text ":router/change", :id "HyetRmFu77"}
+                                 "r" {
+                                  :type :expr, :by "root", :at 1531642836076, :id "ByE2AXK_XQ"
+                                  :data {
+                                   "T" {:type :leaf, :by "root", :at 1531642836477, :text "{}", :id "Symn0XtOQX"}
+                                   "j" {
+                                    :type :expr, :by "root", :at 1531642836671, :id "ryg60QYdQ7"
+                                    :data {
+                                     "T" {:type :leaf, :by "root", :at 1531642837306, :text ":name", :id "B1aCXKO7Q"}
+                                     "j" {:type :leaf, :by "root", :at 1531642848803, :text ":done", :id "SkIpCXtOQ7"}
+                                    }
+                                   }
+                                   "r" {
+                                    :type :expr, :by "root", :at 1531642849562, :id "BycJNtd7X"
+                                    :data {
+                                     "T" {:type :leaf, :by "root", :at 1531642850316, :text ":data", :id "BycJNtd7Xleaf"}
+                                     "j" {:type :leaf, :by "root", :at 1531642853674, :text "year-month", :id "BJHqyEKuQm"}
+                                    }
+                                   }
+                                  }
+                                 }
+                                }
+                               }
+                              }
+                             }
+                            }
+                           }
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "root", :at 1531642582196, :id "rk-0AGYuQX"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1531642582537, :text "<>", :id "rk-0AGYuQXleaf"}
+                           "j" {:type :leaf, :by "root", :at 1531642582993, :text "year-month", :id "ryl1kXYumX"}
                           }
                          }
                         }
@@ -2391,52 +2598,65 @@
                }
               }
              }
-             "T" {
-              :type :expr, :by "root", :at 1524383209919, :id "S1GlCnthG"
+             "R" {
+              :type :expr, :by "root", :at 1531642590470, :id "HklUkmYdXm"
               :data {
-               "D" {:type :leaf, :by "root", :at 1524383212868, :text "list->", :id "HklMgC3Fnz"}
+               "T" {:type :leaf, :by "root", :at 1531642596555, :text "=<", :id "HklUkmYdXmleaf"}
+               "j" {:type :leaf, :by "root", :at 1531642597235, :text "16", :id "H1xpJ7F_QX"}
+               "r" {:type :leaf, :by "root", :at 1531642598161, :text "nil", :id "H1CyXtuXQ"}
+              }
+             }
+             "T" {
+              :type :expr, :by "root", :at 1524383219785, :id "rk3g03K3f"
+              :data {
+               "D" {:type :leaf, :by "root", :at 1524383220461, :text "let", :id "SJx2g0hKnM"}
                "L" {
-                :type :expr, :by "root", :at 1524383213221, :id "SJzrgCnt3M"
+                :type :expr, :by "root", :at 1524383220810, :id "H1aeC3thM"
                 :data {
-                 "T" {:type :leaf, :by "root", :at 1524383214164, :text "{}", :id "BkZHxRht2M"}
-                }
-               }
-               "T" {
-                :type :expr, :by "root", :at 1524383236549, :id "HJT-A3K2M"
-                :data {
-                 "D" {:type :leaf, :by "root", :at 1524383238345, :text "->>", :id "rygpWChKnf"}
-                 "L" {:type :leaf, :by "root", :at 1524383239903, :text "tasks-by-time", :id "SkJzR3tnM"}
-                 "N" {
-                  :type :expr, :by "root", :at 1524383325832, :id "SJLw0nthG"
+                 "T" {
+                  :type :expr, :by "root", :at 1524383220971, :id "BygTgA3KnG"
                   :data {
-                   "T" {:type :leaf, :by "root", :at 1524383337214, :text "sort", :id "SJLw0nthGleaf"}
+                   "T" {:type :leaf, :by "root", :at 1524383227199, :text "tasks-by-time", :id "ByNhxRhKhG"}
                    "j" {
-                    :type :expr, :by "root", :at 1524383337684, :id "ryGORnKnz"
+                    :type :expr, :by "root", :at 1524382730905, :id "S1gDb02Y2M"
                     :data {
-                     "T" {:type :leaf, :by "root", :at 1524383338009, :text "fn", :id "BJfbuAnF3G"}
-                     "j" {
-                      :type :expr, :by "root", :at 1524383338340, :id "r1XzOAhKnf"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1524383348895, :text "pair-a", :id "ryGGOR2F2z"}
-                       "j" {:type :leaf, :by "root", :at 1524383352096, :text "pair-b", :id "BkWC_C3Fnz"}
-                      }
-                     }
+                     "D" {:type :leaf, :by "root", :at 1524382734701, :text "->>", :id "rJl7Gh3tnM"}
+                     "b" {:type :leaf, :by "root", :at 1531642801208, :text "tasks", :id "BkgCcftdm7"}
+                     "j" {:type :leaf, :by "root", :at 1524382743435, :text "vals", :id "H1bwfhhKhG"}
                      "r" {
-                      :type :expr, :by "root", :at 1524383353110, :id "rylZYAhF3z"
+                      :type :expr, :by "root", :at 1524382744775, :id "HyZ7h3K3z"
                       :data {
-                       "T" {:type :leaf, :by "root", :at 1524383357046, :text "compare", :id "rylZYAhF3zleaf"}
+                       "T" {:type :leaf, :by "root", :at 1524382755369, :text "group-by", :id "BJWlXnnY2M"}
                        "j" {
-                        :type :expr, :by "root", :at 1524383361827, :id "rkemnRhKnG"
+                        :type :expr, :by "root", :at 1524382763391, :id "B1bXV23K3f"
                         :data {
-                         "T" {:type :leaf, :by "root", :at 1524383400016, :text "first", :id "SycYA2Fnf"}
-                         "j" {:type :leaf, :by "root", :at 1524383366972, :text "pair-b", :id "S13KA2Y2M"}
-                        }
-                       }
-                       "r" {
-                        :type :expr, :by "root", :at 1524383361827, :id "S1PhCnFnM"
-                        :data {
-                         "T" {:type :leaf, :by "root", :at 1524383405477, :text "first", :id "SycYA2Fnf"}
-                         "j" {:type :leaf, :by "root", :at 1524383370782, :text "pair-a", :id "S13KA2Y2M"}
+                         "T" {:type :leaf, :by "root", :at 1524382765141, :text "fn", :id "BJZEh2tnM"}
+                         "j" {
+                          :type :expr, :by "root", :at 1524382765831, :id "BJeI433Knz"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1524382768723, :text "task", :id "B1I4n3FhM"}
+                          }
+                         }
+                         "v" {
+                          :type :expr, :by "root", :at 1524382951916, :id "S1HKVFdX7"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1529162222704, :text ".format", :id "ryxleahK2zleaf"}
+                           "j" {
+                            :type :expr, :by "root", :at 1529162223644, :id "Sy_x9sMZQ"
+                            :data {
+                             "T" {:type :leaf, :by "root", :at 1529162225353, :text "dayjs", :id "SkGExT2FhM"}
+                             "j" {
+                              :type :expr, :by "root", :at 1524383102245, :id "BkYtVFOXX"
+                              :data {
+                               "T" {:type :leaf, :by "root", :at 1524383147149, :text ":time", :id "SJ8Ya3K3z"}
+                               "j" {:type :leaf, :by "root", :at 1524383107299, :text "task", :id "HyiY63Fnz"}
+                              }
+                             }
+                            }
+                           }
+                           "r" {:type :leaf, :by "root", :at 1531642999064, :text "\"DD", :id "H1QLgahYnz"}
+                          }
+                         }
                         }
                        }
                       }
@@ -2445,158 +2665,216 @@
                    }
                   }
                  }
-                 "P" {
-                  :type :expr, :by "root", :at 1524383240825, :id "r1ZzRhFhz"
+                }
+               }
+               "T" {
+                :type :expr, :by "root", :at 1524383209919, :id "S1GlCnthG"
+                :data {
+                 "D" {:type :leaf, :by "root", :at 1524383212868, :text "list->", :id "HklMgC3Fnz"}
+                 "L" {
+                  :type :expr, :by "root", :at 1524383213221, :id "SJzrgCnt3M"
                   :data {
-                   "T" {:type :leaf, :by "root", :at 1524383242250, :text "map", :id "ryeeGA3K3f"}
-                   "j" {
-                    :type :expr, :by "root", :at 1524383242646, :id "S1QzRhthG"
+                   "T" {:type :leaf, :by "root", :at 1524383214164, :text "{}", :id "BkZHxRht2M"}
+                  }
+                 }
+                 "T" {
+                  :type :expr, :by "root", :at 1524383236549, :id "HJT-A3K2M"
+                  :data {
+                   "D" {:type :leaf, :by "root", :at 1524383238345, :text "->>", :id "rygpWChKnf"}
+                   "L" {:type :leaf, :by "root", :at 1524383239903, :text "tasks-by-time", :id "SkJzR3tnM"}
+                   "N" {
+                    :type :expr, :by "root", :at 1524383325832, :id "SJLw0nthG"
                     :data {
-                     "T" {:type :leaf, :by "root", :at 1524383243512, :text "fn", :id "Bk4MGCnKhz"}
+                     "T" {:type :leaf, :by "root", :at 1524383337214, :text "sort", :id "SJLw0nthGleaf"}
                      "j" {
-                      :type :expr, :by "root", :at 1524383243842, :id "B1l4fCnK2G"
+                      :type :expr, :by "root", :at 1524383337684, :id "ryGORnKnz"
                       :data {
-                       "T" {
-                        :type :expr, :by "root", :at 1524383246882, :id "HJwGR3F3G"
+                       "T" {:type :leaf, :by "root", :at 1524383338009, :text "fn", :id "BJfbuAnF3G"}
+                       "j" {
+                        :type :expr, :by "root", :at 1524383338340, :id "r1XzOAhKnf"
                         :data {
-                         "T" {:type :leaf, :by "root", :at 1524383247162, :text "[]", :id "BkVGA3t2G"}
-                         "j" {:type :leaf, :by "root", :at 1524383250209, :text "date", :id "B1OMC3KhG"}
-                         "r" {:type :leaf, :by "root", :at 1524383251459, :text "tasks", :id "Bk-9zRnYhf"}
+                         "T" {:type :leaf, :by "root", :at 1524383348895, :text "pair-a", :id "ryGGOR2F2z"}
+                         "j" {:type :leaf, :by "root", :at 1524383352096, :text "pair-b", :id "BkWC_C3Fnz"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "root", :at 1524383353110, :id "rylZYAhF3z"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1524383357046, :text "compare", :id "rylZYAhF3zleaf"}
+                         "j" {
+                          :type :expr, :by "root", :at 1524383361827, :id "rkemnRhKnG"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1524383400016, :text "first", :id "SycYA2Fnf"}
+                           "j" {:type :leaf, :by "root", :at 1524383366972, :text "pair-b", :id "S13KA2Y2M"}
+                          }
+                         }
+                         "r" {
+                          :type :expr, :by "root", :at 1524383361827, :id "S1PhCnFnM"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1524383405477, :text "first", :id "SycYA2Fnf"}
+                           "j" {:type :leaf, :by "root", :at 1524383370782, :text "pair-a", :id "S13KA2Y2M"}
+                          }
+                         }
                         }
                        }
                       }
                      }
-                     "r" {
-                      :type :expr, :by "root", :at 1524383254583, :id "HJk7AhY2G"
+                    }
+                   }
+                   "P" {
+                    :type :expr, :by "root", :at 1524383240825, :id "r1ZzRhFhz"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1524383242250, :text "map", :id "ryeeGA3K3f"}
+                     "j" {
+                      :type :expr, :by "root", :at 1524383242646, :id "S1QzRhthG"
                       :data {
-                       "T" {:type :leaf, :by "root", :at 1524383255098, :text "[]", :id "HJk7AhY2Gleaf"}
-                       "j" {:type :leaf, :by "root", :at 1524383258567, :text "date", :id "ByxfXChFnf"}
-                       "r" {
-                        :type :expr, :by "root", :at 1524383258941, :id "H1ZX7R2YhG"
+                       "T" {:type :leaf, :by "root", :at 1524383243512, :text "fn", :id "Bk4MGCnKhz"}
+                       "j" {
+                        :type :expr, :by "root", :at 1524383243842, :id "B1l4fCnK2G"
                         :data {
-                         "T" {:type :leaf, :by "root", :at 1524383259676, :text "div", :id "BJemQAnYnf"}
-                         "j" {
-                          :type :expr, :by "root", :at 1524383259879, :id "SkGVXChK2f"
+                         "T" {
+                          :type :expr, :by "root", :at 1524383246882, :id "HJwGR3F3G"
                           :data {
-                           "T" {:type :leaf, :by "root", :at 1524383260211, :text "{}", :id "HyWEXR2t2z"}
+                           "T" {:type :leaf, :by "root", :at 1524383247162, :text "[]", :id "BkVGA3t2G"}
+                           "j" {:type :leaf, :by "root", :at 1524383250209, :text "date", :id "B1OMC3KhG"}
+                           "r" {:type :leaf, :by "root", :at 1524383251459, :text "tasks", :id "Bk-9zRnYhf"}
                           }
                          }
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "root", :at 1524383254583, :id "HJk7AhY2G"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1524383255098, :text "[]", :id "HJk7AhY2Gleaf"}
+                         "j" {:type :leaf, :by "root", :at 1524383258567, :text "date", :id "ByxfXChFnf"}
                          "r" {
-                          :type :expr, :by "root", :at 1524383484156, :id "HkZ4bk6Ynz"
+                          :type :expr, :by "root", :at 1524383258941, :id "H1ZX7R2YhG"
                           :data {
-                           "D" {:type :leaf, :by "root", :at 1524383484800, :text "div", :id "SyzNbkpKnz"}
-                           "L" {
-                            :type :expr, :by "root", :at 1524383486340, :id "r1Z8ZypYhz"
+                           "T" {:type :leaf, :by "root", :at 1524383259676, :text "div", :id "BJemQAnYnf"}
+                           "j" {
+                            :type :expr, :by "root", :at 1524383259879, :id "SkGVXChK2f"
                             :data {
-                             "T" {:type :leaf, :by "root", :at 1524383486682, :text "{}", :id "SygIZJaKnz"}
-                             "j" {
-                              :type :expr, :by "root", :at 1524383486924, :id "ryfDbJ6Ynf"
+                             "T" {:type :leaf, :by "root", :at 1524383260211, :text "{}", :id "HyWEXR2t2z"}
+                            }
+                           }
+                           "r" {
+                            :type :expr, :by "root", :at 1524383484156, :id "HkZ4bk6Ynz"
+                            :data {
+                             "D" {:type :leaf, :by "root", :at 1524383484800, :text "div", :id "SyzNbkpKnz"}
+                             "L" {
+                              :type :expr, :by "root", :at 1524383486340, :id "r1Z8ZypYhz"
                               :data {
-                               "T" {:type :leaf, :by "root", :at 1524383487652, :text ":style", :id "S1WvWy6thM"}
+                               "T" {:type :leaf, :by "root", :at 1524383486682, :text "{}", :id "SygIZJaKnz"}
                                "j" {
-                                :type :expr, :by "root", :at 1524383487844, :id "Hyf_byTK3f"
+                                :type :expr, :by "root", :at 1524383486924, :id "ryfDbJ6Ynf"
                                 :data {
-                                 "T" {:type :leaf, :by "root", :at 1524383488170, :text "{}", :id "BJbu-kTK3f"}
+                                 "T" {:type :leaf, :by "root", :at 1524383487652, :text ":style", :id "S1WvWy6thM"}
                                  "j" {
-                                  :type :expr, :by "root", :at 1524383488470, :id "HyU_-1TF3M"
+                                  :type :expr, :by "root", :at 1524383487844, :id "Hyf_byTK3f"
                                   :data {
-                                   "T" {:type :leaf, :by "root", :at 1524383491824, :text ":font-family", :id "ByS_bJTYhG"}
-                                   "j" {:type :leaf, :by "root", :at 1524383495429, :text "ui/font-fancy", :id "HkW2WyaF3f"}
-                                  }
-                                 }
-                                 "r" {
-                                  :type :expr, :by "root", :at 1524383496232, :id "HJfxGJTtnf"
-                                  :data {
-                                   "T" {:type :leaf, :by "root", :at 1524383497551, :text ":font-size", :id "HJfxGJTtnfleaf"}
-                                   "j" {:type :leaf, :by "root", :at 1524383499001, :text "16", :id "ryxMz16YnM"}
-                                  }
-                                 }
-                                 "v" {
-                                  :type :expr, :by "root", :at 1524383504201, :id "r1ldGJ6thf"
-                                  :data {
-                                   "T" {:type :leaf, :by "root", :at 1524383506556, :text ":font-weight", :id "r1ldGJ6thfleaf"}
-                                   "j" {:type :leaf, :by "root", :at 1524383508068, :text "100", :id "r1gjMk6F2z"}
-                                  }
-                                 }
-                                 "x" {
-                                  :type :expr, :by "root", :at 1524383510227, :id "Byf0GJaKnG"
-                                  :data {
-                                   "T" {:type :leaf, :by "root", :at 1524383511762, :text ":margin-top", :id "ryxpGkaY3z"}
-                                   "j" {:type :leaf, :by "root", :at 1524383512599, :text "16", :id "H1feQkTt3G"}
-                                  }
-                                 }
-                                 "y" {
-                                  :type :expr, :by "root", :at 1524383525531, :id "ByC7JpF3M"
-                                  :data {
-                                   "T" {:type :leaf, :by "root", :at 1524383528557, :text ":line-height", :id "ByC7JpF3Mleaf"}
-                                   "j" {:type :leaf, :by "root", :at 1524383530563, :text "\"24px", :id "ryeZ4ypK2G"}
+                                   "T" {:type :leaf, :by "root", :at 1524383488170, :text "{}", :id "BJbu-kTK3f"}
+                                   "j" {
+                                    :type :expr, :by "root", :at 1524383488470, :id "HyU_-1TF3M"
+                                    :data {
+                                     "T" {:type :leaf, :by "root", :at 1524383491824, :text ":font-family", :id "ByS_bJTYhG"}
+                                     "j" {:type :leaf, :by "root", :at 1524383495429, :text "ui/font-fancy", :id "HkW2WyaF3f"}
+                                    }
+                                   }
+                                   "r" {
+                                    :type :expr, :by "root", :at 1524383496232, :id "HJfxGJTtnf"
+                                    :data {
+                                     "T" {:type :leaf, :by "root", :at 1524383497551, :text ":font-size", :id "HJfxGJTtnfleaf"}
+                                     "j" {:type :leaf, :by "root", :at 1524383499001, :text "16", :id "ryxMz16YnM"}
+                                    }
+                                   }
+                                   "v" {
+                                    :type :expr, :by "root", :at 1524383504201, :id "r1ldGJ6thf"
+                                    :data {
+                                     "T" {:type :leaf, :by "root", :at 1524383506556, :text ":font-weight", :id "r1ldGJ6thfleaf"}
+                                     "j" {:type :leaf, :by "root", :at 1524383508068, :text "100", :id "r1gjMk6F2z"}
+                                    }
+                                   }
+                                   "x" {
+                                    :type :expr, :by "root", :at 1524383510227, :id "Byf0GJaKnG"
+                                    :data {
+                                     "T" {:type :leaf, :by "root", :at 1524383511762, :text ":margin-top", :id "ryxpGkaY3z"}
+                                     "j" {:type :leaf, :by "root", :at 1524383512599, :text "16", :id "H1feQkTt3G"}
+                                    }
+                                   }
+                                   "y" {
+                                    :type :expr, :by "root", :at 1524383525531, :id "ByC7JpF3M"
+                                    :data {
+                                     "T" {:type :leaf, :by "root", :at 1524383528557, :text ":line-height", :id "ByC7JpF3Mleaf"}
+                                     "j" {:type :leaf, :by "root", :at 1524383530563, :text "\"24px", :id "ryeZ4ypK2G"}
+                                    }
+                                   }
                                   }
                                  }
                                 }
                                }
                               }
                              }
-                            }
-                           }
-                           "T" {
-                            :type :expr, :by "root", :at 1524383261799, :id "rJLmAnYhM"
-                            :data {
-                             "T" {:type :leaf, :by "root", :at 1524383262334, :text "<>", :id "rJLmAnYhMleaf"}
-                             "j" {:type :leaf, :by "root", :at 1524383263730, :text "date", :id "ByPQ0hY2f"}
-                            }
-                           }
-                          }
-                         }
-                         "v" {
-                          :type :expr, :by "root", :at 1521045542477, :id "HJ3Q03t3z"
-                          :data {
-                           "T" {:type :leaf, :by "root", :at 1521045631182, :text "list->", :id "r1lAQe0LKfleaf"}
-                           "j" {
-                            :type :expr, :by "root", :at 1521045632825, :id "HJYYgCIKz"
-                            :data {
-                             "T" {:type :leaf, :by "root", :at 1521045633133, :text "{}", :id "SJXzNgCIKf"}
-                            }
-                           }
-                           "r" {
-                            :type :expr, :by "root", :at 1521045634512, :id "H1ZcYgA8tz"
-                            :data {
-                             "T" {:type :leaf, :by "root", :at 1521045635219, :text "->>", :id "Hye9Yg0IKG"}
-                             "j" {:type :leaf, :by "root", :at 1524383273083, :text "tasks", :id "BJ2KeCUFf"}
-                             "r" {
-                              :type :expr, :by "root", :at 1521045639284, :id "SyNkqgRUtz"
+                             "T" {
+                              :type :expr, :by "root", :at 1524383261799, :id "rJLmAnYhM"
                               :data {
-                               "T" {:type :leaf, :by "root", :at 1524383275650, :text "map", :id "HyQk9eR8tM"}
-                               "j" {
-                                :type :expr, :by "root", :at 1521045641688, :id "BJeMqlCUtG"
+                               "T" {:type :leaf, :by "root", :at 1524383262334, :text "<>", :id "rJLmAnYhMleaf"}
+                               "j" {:type :leaf, :by "root", :at 1524383263730, :text "date", :id "ByPQ0hY2f"}
+                              }
+                             }
+                            }
+                           }
+                           "v" {
+                            :type :expr, :by "root", :at 1521045542477, :id "HJ3Q03t3z"
+                            :data {
+                             "T" {:type :leaf, :by "root", :at 1521045631182, :text "list->", :id "r1lAQe0LKfleaf"}
+                             "j" {
+                              :type :expr, :by "root", :at 1521045632825, :id "HJYYgCIKz"
+                              :data {
+                               "T" {:type :leaf, :by "root", :at 1521045633133, :text "{}", :id "SJXzNgCIKf"}
+                              }
+                             }
+                             "r" {
+                              :type :expr, :by "root", :at 1521045634512, :id "H1ZcYgA8tz"
+                              :data {
+                               "T" {:type :leaf, :by "root", :at 1521045635219, :text "->>", :id "Hye9Yg0IKG"}
+                               "j" {:type :leaf, :by "root", :at 1524383273083, :text "tasks", :id "BJ2KeCUFf"}
+                               "r" {
+                                :type :expr, :by "root", :at 1521045639284, :id "SyNkqgRUtz"
                                 :data {
-                                 "T" {:type :leaf, :by "root", :at 1521045642020, :text "fn", :id "BJMql0IYG"}
+                                 "T" {:type :leaf, :by "root", :at 1524383275650, :text "map", :id "HyQk9eR8tM"}
                                  "j" {
-                                  :type :expr, :by "root", :at 1521045642617, :id "SJ7qgCUtz"
+                                  :type :expr, :by "root", :at 1521045641688, :id "BJeMqlCUtG"
                                   :data {
-                                   "T" {:type :leaf, :by "root", :at 1521045643127, :text "task", :id "B1mz9eRItM"}
-                                  }
-                                 }
-                                 "r" {
-                                  :type :expr, :by "root", :at 1524383277519, :id "B18NRnYnf"
-                                  :data {
-                                   "D" {:type :leaf, :by "root", :at 1524383280227, :text "[]", :id "SylU4R3thG"}
-                                   "L" {
-                                    :type :expr, :by "root", :at 1524383288382, :id "HJmxH02Y3f"
+                                   "T" {:type :leaf, :by "root", :at 1521045642020, :text "fn", :id "BJMql0IYG"}
+                                   "j" {
+                                    :type :expr, :by "root", :at 1521045642617, :id "SJ7qgCUtz"
                                     :data {
-                                     "T" {:type :leaf, :by "root", :at 1524383287736, :text ":id", :id "ryt4AnY3z"}
-                                     "j" {:type :leaf, :by "root", :at 1524383289072, :text "task", :id "HybBCnthM"}
+                                     "T" {:type :leaf, :by "root", :at 1521045643127, :text "task", :id "B1mz9eRItM"}
                                     }
                                    }
-                                   "T" {
-                                    :type :expr, :by "root", :at 1524383453280, :id "rkSJJpK2z"
+                                   "r" {
+                                    :type :expr, :by "root", :at 1524383277519, :id "B18NRnYnf"
                                     :data {
-                                     "T" {:type :leaf, :by "root", :at 1524383437936, :text "comp-done-task", :id "rkASLRA3K2M"}
-                                     "j" {:type :leaf, :by "root", :at 1524383454454, :text "task", :id "ByLk1pFnG"}
-                                     "r" {
-                                      :type :expr, :by "root", :at 1530033243058, :id "B1Qw4egGQ"
+                                     "D" {:type :leaf, :by "root", :at 1524383280227, :text "[]", :id "SylU4R3thG"}
+                                     "L" {
+                                      :type :expr, :by "root", :at 1524383288382, :id "HJmxH02Y3f"
                                       :data {
-                                       "T" {:type :leaf, :by "root", :at 1530033245105, :text ":editing?", :id "SyezPVxxfX"}
-                                       "j" {:type :leaf, :by "root", :at 1530033246749, :text "state", :id "SJxrvNelfm"}
+                                       "T" {:type :leaf, :by "root", :at 1524383287736, :text ":id", :id "ryt4AnY3z"}
+                                       "j" {:type :leaf, :by "root", :at 1524383289072, :text "task", :id "HybBCnthM"}
+                                      }
+                                     }
+                                     "T" {
+                                      :type :expr, :by "root", :at 1524383453280, :id "rkSJJpK2z"
+                                      :data {
+                                       "T" {:type :leaf, :by "root", :at 1524383437936, :text "comp-done-task", :id "rkASLRA3K2M"}
+                                       "j" {:type :leaf, :by "root", :at 1524383454454, :text "task", :id "ByLk1pFnG"}
+                                       "r" {
+                                        :type :expr, :by "root", :at 1530033243058, :id "B1Qw4egGQ"
+                                        :data {
+                                         "T" {:type :leaf, :by "root", :at 1530033245105, :text ":editing?", :id "SyezPVxxfX"}
+                                         "j" {:type :leaf, :by "root", :at 1530033246749, :text "state", :id "SJxrvNelfm"}
+                                        }
+                                       }
                                       }
                                      }
                                     }
@@ -9135,8 +9413,15 @@
          "y" {
           :type :expr, :by "root", :at 1521043256016, :id "SyxeSvTUYz"
           :data {
-           "T" {:type :leaf, :by "root", :at 1521043275172, :text ":text-time", :id "SyxeSvTUYzleaf"}
-           "j" {:type :leaf, :by "root", :at 1521043276596, :text "|", :id "SkVUwp8Kz"}
+           "T" {:type :leaf, :by "root", :at 1531642132141, :text ":mode", :id "SyxeSvTUYzleaf"}
+           "j" {:type :leaf, :by "root", :at 1531642134410, :text "nil", :id "SkVUwp8Kz"}
+          }
+         }
+         "yT" {
+          :type :expr, :by "root", :at 1531642134885, :id "BkxyXWYdQm"
+          :data {
+           "T" {:type :leaf, :by "root", :at 1531642136097, :text ":time", :id "BkxyXWYdQmleaf"}
+           "j" {:type :leaf, :by "root", :at 1531642136874, :text "0", :id "SJQeXbFuQX"}
           }
          }
         }
@@ -10871,6 +11156,15 @@
           "v" {:type :leaf, :by "root", :at 1524244394478, :text "color", :id "Sy-Ghyivhf"}
          }
         }
+        "x" {
+         :type :expr, :by "root", :at 1531642248574, :id "ByWcZFd7Q"
+         :data {
+          "T" {:type :leaf, :by "root", :at 1531642248942, :text "[]", :id "ByWcZFd7Qleaf"}
+          "j" {:type :leaf, :by "root", :at 1531642251350, :text "\"dayjs", :id "ryMWcWKOm7"}
+          "r" {:type :leaf, :by "root", :at 1531642252707, :text ":as", :id "rk7X9WtdQ7"}
+          "v" {:type :leaf, :by "root", :at 1531642254376, :text "dayjs", :id "HJZSqZKdmX"}
+         }
+        }
        }
       }
      }
@@ -11084,10 +11378,23 @@
                         :data {
                          "T" {:type :leaf, :by "root", :at 1520962656662, :text ":done", :id "BkePD3YBYzleaf"}
                          "j" {
-                          :type :expr, :by "root", :at 1520962822697, :id "HyeyzTFrFM"
+                          :type :expr, :by "root", :at 1531641878687, :id "Skxk7gtO7Q"
                           :data {
-                           "T" {:type :leaf, :by "root", :at 1520962825409, :text ":done-tasks", :id "B1JzaKSYf"}
-                           "j" {:type :leaf, :by "root", :at 1521563811813, :text "user", :id "Skzz6trYz"}
+                           "D" {:type :leaf, :by "root", :at 1531641884818, :text "twig-done-tasks", :id "BJ-17lt_X7"}
+                           "T" {
+                            :type :expr, :by "root", :at 1520962822697, :id "HyeyzTFrFM"
+                            :data {
+                             "T" {:type :leaf, :by "root", :at 1520962825409, :text ":done-tasks", :id "B1JzaKSYf"}
+                             "j" {:type :leaf, :by "root", :at 1521563811813, :text "user", :id "Skzz6trYz"}
+                            }
+                           }
+                           "j" {
+                            :type :expr, :by "root", :at 1531641888223, :id "Skgd7gtdX7"
+                            :data {
+                             "T" {:type :leaf, :by "root", :at 1531641890243, :text ":data", :id "H1UXgtuQQ"}
+                             "j" {:type :leaf, :by "root", :at 1531641890969, :text "router", :id "Hy89mxY_XQ"}
+                            }
+                           }
                           }
                          }
                         }
@@ -11209,6 +11516,210 @@
               }
              }
              "v" {:type :leaf, :text "nil", :id "ryg7ssXahb", :by "root", :at 1507830683551}
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+     "twig-done-tasks" {
+      :type :expr, :by "root", :at 1531641892912, :id "rk-ametOmQ"
+      :data {
+       "T" {:type :leaf, :by "root", :at 1531641913880, :text "deftwig", :id "HJfp7eYd7X"}
+       "j" {:type :leaf, :by "root", :at 1531641892912, :text "twig-done-tasks", :id "SyQp7gKdXQ"}
+       "r" {
+        :type :expr, :by "root", :at 1531641892912, :id "rJ4pQxYdQm"
+        :data {
+         "T" {:type :leaf, :by "root", :at 1531641901206, :text "done-tasks", :id "HyZAXltdXm"}
+         "j" {:type :leaf, :by "root", :at 1531641911630, :text "year-month", :id "HkDNetdXm"}
+        }
+       }
+       "t" {
+        :type :expr, :by "root", :at 1531641998967, :id "BkPcgKu77"
+        :data {
+         "T" {:type :leaf, :by "root", :at 1531642000376, :text "let", :id "BkPcgKu77leaf"}
+         "j" {
+          :type :expr, :by "root", :at 1531642000601, :id "SkF5etdXm"
+          :data {
+           "T" {
+            :type :expr, :by "root", :at 1531642002195, :id "rkZcceKdQm"
+            :data {
+             "T" {:type :leaf, :by "root", :at 1531642005801, :text "year-months", :id "H1muqgKuQX"}
+             "j" {
+              :type :expr, :by "root", :at 1531642007645, :id "Bkeoxtumm"
+              :data {
+               "T" {:type :leaf, :by "root", :at 1531642065758, :text "->>", :id "H1JoxF_7X"}
+               "j" {:type :leaf, :by "root", :at 1531642011167, :text "done-tasks", :id "ry-WsxKu77"}
+               "r" {:type :leaf, :by "root", :at 1531642013967, :text "vals", :id "rkrsxtO7X"}
+               "v" {
+                :type :expr, :by "root", :at 1531642078519, :id "HkvJWt_X7"
+                :data {
+                 "D" {:type :leaf, :by "root", :at 1531642080069, :text "map", :id "SygPkZKumX"}
+                 "T" {:type :leaf, :by "root", :at 1531642078026, :text ":time", :id "HkHJZFOX7"}
+                }
+               }
+               "y" {
+                :type :expr, :by "root", :at 1531642240838, :id "ryeKYWtu7Q"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1531642243265, :text "map", :id "ryYFbF_7m"}
+                 "j" {
+                  :type :expr, :by "root", :at 1531642243626, :id "B13FZYuQ7"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1531642243975, :text "fn", :id "SJzitZYd7X"}
+                   "j" {
+                    :type :expr, :by "root", :at 1531642245143, :id "H1gaYZt_m7"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1531642245587, :text "x", :id "Hkf2F-KO7X"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "root", :at 1531642259445, :id "By-o5WKOQQ"
+                    :data {
+                     "D" {:type :leaf, :by "root", :at 1531642260703, :text ".format", :id "B139-tO7m"}
+                     "T" {
+                      :type :expr, :by "root", :at 1531642257285, :id "HkgK9-KuQQ"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1531642257666, :text "dayjs", :id "HkgK9-KuQQleaf"}
+                       "j" {:type :leaf, :by "root", :at 1531642258853, :text "x", :id "HJxc9bY_XQ"}
+                      }
+                     }
+                     "j" {:type :leaf, :by "root", :at 1531642269571, :text "\"YYYY-MM", :id "ryGTcWYuQ7"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "yT" {:type :leaf, :by "root", :at 1531642691484, :text "distinct", :id "B1iSXKO7X"}
+              }
+             }
+            }
+           }
+           "j" {
+            :type :expr, :by "root", :at 1531642306229, :id "r1lqaZKuXQ"
+            :data {
+             "T" {:type :leaf, :by "root", :at 1531642311487, :text "cursor", :id "r1lqaZKuXQleaf"}
+             "j" {
+              :type :expr, :by "root", :at 1531642312311, :id "HyeeRbKuQm"
+              :data {
+               "T" {:type :leaf, :by "root", :at 1531642312593, :text "or", :id "BklAZKOQQ"}
+               "j" {:type :leaf, :by "root", :at 1531642320869, :text "year-month", :id "r1V0bK_Q7"}
+               "r" {
+                :type :expr, :by "root", :at 1531642324718, :id "SyTAWKu77"
+                :data {
+                 "D" {:type :leaf, :by "root", :at 1531642336925, :text "apply", :id "rJdkfYuX7"}
+                 "T" {:type :leaf, :by "root", :at 1531642330913, :text "max", :id "ryGK0WKO7m"}
+                 "j" {:type :leaf, :by "root", :at 1531642452708, :text "year-months", :id "S1gpCbKOX7"}
+                }
+               }
+              }
+             }
+            }
+           }
+           "r" {
+            :type :expr, :by "root", :at 1531642343598, :id "r1gxftuQ7"
+            :data {
+             "T" {:type :leaf, :by "root", :at 1531642417788, :text "reading-tasks", :id "r1gxftuQ7leaf"}
+             "j" {
+              :type :expr, :by "root", :at 1531642353337, :id "SJlFezYdXm"
+              :data {
+               "T" {:type :leaf, :by "root", :at 1531642356224, :text "->>", :id "HktefKdXQ"}
+               "j" {:type :leaf, :by "root", :at 1531642358261, :text "done-tasks", :id "H1GheMtumQ"}
+               "r" {
+                :type :expr, :by "root", :at 1531642359586, :id "BJebMFuXm"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1531642360981, :text "filter", :id "ryyZfK_XX"}
+                 "j" {
+                  :type :expr, :by "root", :at 1531642361481, :id "H1NW-fF_Q7"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1531642362558, :text "fn", :id "SkmbWfK_mX"}
+                   "j" {
+                    :type :expr, :by "root", :at 1531642362987, :id "rJZm-GFOXm"
+                    :data {
+                     "T" {
+                      :type :expr, :by "root", :at 1531642363578, :id "SyVWMFd7X"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1531642364080, :text "[]", :id "H1xmWGYOXm"}
+                       "j" {:type :leaf, :by "root", :at 1531642364660, :text "k", :id "SkHbztOm7"}
+                       "r" {:type :leaf, :by "root", :at 1531642365602, :text "task", :id "B1bHWzYuXm"}
+                      }
+                     }
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "root", :at 1531642366677, :id "S1vWzK_QQ"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1531642366954, :text "=", :id "S1vWzK_QQleaf"}
+                     "j" {:type :leaf, :by "root", :at 1531642369205, :text "cursor", :id "H1u-GYdXX"}
+                     "r" {
+                      :type :expr, :by "root", :at 1531642374205, :id "HJ-RbGY_Xm"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1531642377851, :text ".format", :id "B1xRWztum7"}
+                       "j" {
+                        :type :expr, :by "root", :at 1531642381909, :id "SklIfMFO7m"
+                        :data {
+                         "D" {:type :leaf, :by "root", :at 1531642383478, :text "dayjs", :id "BybLMzKdXm"}
+                         "T" {
+                          :type :expr, :by "root", :at 1531642378861, :id "Bye7ffFuQm"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1531642379470, :text ":time", :id "SkQfMFu77"}
+                           "j" {:type :leaf, :by "root", :at 1531642381394, :text "task", :id "HyEffKdmX"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {:type :leaf, :by "root", :at 1531642386987, :text "\"YYYY-MM", :id "ByguGMF_mX"}
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "v" {
+                :type :expr, :by "root", :at 1531642391227, :id "rkkXMK_7m"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1531642391860, :text "into", :id "rkkXMK_7mleaf"}
+                 "j" {
+                  :type :expr, :by "root", :at 1531642392281, :id "B1VgQzFOQX"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1531642392648, :text "{}", :id "B1Qx7zYuQ7"}
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+         "r" {
+          :type :expr, :by "root", :at 1531641916741, :id "Hkls6lK_Qm"
+          :data {
+           "T" {:type :leaf, :by "root", :at 1531641917121, :text "{}", :id "r1xNSgYdQm"}
+           "j" {
+            :type :expr, :by "root", :at 1531642035836, :id "H1b2hetOQX"
+            :data {
+             "T" {:type :leaf, :by "root", :at 1531642037271, :text ":months", :id "SJx23xFO7Q"}
+             "j" {:type :leaf, :by "root", :at 1531642037961, :text "year-months", :id "ryQTnetumQ"}
+            }
+           }
+           "n" {
+            :type :expr, :by "root", :at 1531642425330, :id "rylbrGKO7m"
+            :data {
+             "T" {:type :leaf, :by "root", :at 1531642427777, :text ":cursor", :id "rylbrGKO7mleaf"}
+             "j" {:type :leaf, :by "root", :at 1531642429405, :text "cursor", :id "B1bVrfFdXm"}
+            }
+           }
+           "r" {
+            :type :expr, :by "root", :at 1531642395763, :id "rkVQGt_Xm"
+            :data {
+             "T" {:type :leaf, :by "root", :at 1531642420163, :text ":tasks", :id "rkVQGt_Xmleaf"}
+             "j" {:type :leaf, :by "root", :at 1531642423871, :text "reading-tasks", :id "HJV37GYdQX"}
             }
            }
           }
@@ -13213,33 +13724,6 @@
          }
          "r" {:type :leaf, :id "BkmweL-xCr-", :text "nil", :by "root", :at 1500541255553}
          "v" {:type :leaf, :id "ByEvlLbxRSb", :text "xs", :by "root", :at 1500541255553}
-        }
-       }
-      }
-     }
-     "format-date" {
-      :type :expr, :by "root", :at 1524382802851, :id "H1ej83hF3G"
-      :data {
-       "T" {:type :leaf, :by "root", :at 1524382802851, :text "defn", :id "rk-iU33t2M"}
-       "j" {:type :leaf, :by "root", :at 1524382802851, :text "format-date", :id "ryfjI2hY2f"}
-       "r" {
-        :type :expr, :by "root", :at 1524382802851, :id "BJ7jU2ht3M"
-        :data {
-         "T" {:type :leaf, :by "root", :at 1524382811615, :text "unix-time", :id "S1xlP32F2z"}
-        }
-       }
-       "v" {
-        :type :expr, :by "root", :at 1524382951916, :id "rkxMZciz-m"
-        :data {
-         "T" {:type :leaf, :by "root", :at 1529162222704, :text ".format", :id "ryxleahK2zleaf"}
-         "j" {
-          :type :expr, :by "root", :at 1529162223644, :id "Sy_x9sMZQ"
-          :data {
-           "T" {:type :leaf, :by "root", :at 1529162225353, :text "dayjs", :id "SkGExT2FhM"}
-           "j" {:type :leaf, :by "root", :at 1529162228903, :text "unix-time", :id "By5eqiMZX"}
-          }
-         }
-         "r" {:type :leaf, :by "root", :at 1529162233219, :text "\"YYYY-MM-DD", :id "H1QLgahYnz"}
         }
        }
       }

--- a/calcit.edn
+++ b/calcit.edn
@@ -2170,6 +2170,7 @@
                 :data {
                  "D" {:type :leaf, :by "root", :at 1522254622958, :text "merge", :id "BJM8XmBtqf"}
                  "L" {:type :leaf, :by "root", :at 1522254624876, :text "ui/flex", :id "By4wXmHK9z"}
+                 "P" {:type :leaf, :by "root", :at 1531643672321, :text "ui/row", :id "Byex7DtdXQ"}
                  "T" {
                   :type :expr, :by "root", :at 1521045583125, :id "ry4DIlRLtG"
                   :data {
@@ -2181,188 +2182,6 @@
                      "j" {:type :leaf, :by "root", :at 1521045591220, :text "16", :id "Hy40Lx0UtG"}
                     }
                    }
-                   "r" {
-                    :type :expr, :by "root", :at 1522254612113, :id "rkWhfmrt5f"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1522254613542, :text ":overflow", :id "rkWhfmrt5fleaf"}
-                     "j" {:type :leaf, :by "root", :at 1522254614854, :text ":auto", :id "ryeRf7HFqz"}
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-            }
-           }
-           "r" {
-            :type :expr, :by "root", :at 1521045551385, :id "BygD4gAUFz"
-            :data {
-             "T" {:type :leaf, :by "root", :at 1521045552182, :text "div", :id "r1fIEeA8Kz"}
-             "j" {
-              :type :expr, :by "root", :at 1521045552483, :id "BkM_ExRIYM"
-              :data {
-               "T" {:type :leaf, :by "root", :at 1521045552817, :text "{}", :id "B1-u4gCIFM"}
-              }
-             }
-             "r" {
-              :type :expr, :by "root", :at 1521132750884, :id "r1lPAE7uYG"
-              :data {
-               "D" {:type :leaf, :by "root", :at 1521132751621, :text "<>", :id "r1bwCV7dYf"}
-               "T" {
-                :type :expr, :by "root", :at 1521045553893, :id "rylcNxR8KG"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1521132750289, :text "str", :id "rylcNxR8KGleaf"}
-                 "j" {:type :leaf, :by "root", :at 1531643563714, :text "|Done Tasks(", :id "BJfhNxCLKz"}
-                 "n" {
-                  :type :expr, :by "root", :at 1531643568035, :id "SJOh8Y_7Q"
-                  :data {
-                   "T" {:type :leaf, :by "root", :at 1531643568693, :text "count", :id "r1P2LYuQX"}
-                   "j" {:type :leaf, :by "root", :at 1531643569494, :text "tasks", :id "BJbY2IYOX7"}
-                  }
-                 }
-                 "r" {:type :leaf, :by "root", :at 1531643566177, :text "\")", :id "rkgN3IYuQm"}
-                }
-               }
-               "j" {
-                :type :expr, :by "root", :at 1521045597163, :id "rJQBDgRLKz"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1521045597485, :text "{}", :id "HJfBPxRUKM"}
-                 "j" {
-                  :type :expr, :by "root", :at 1521045597703, :id "BklIveRUKf"
-                  :data {
-                   "T" {:type :leaf, :by "root", :at 1521045599185, :text ":font-size", :id "H18PgAUFG"}
-                   "j" {:type :leaf, :by "root", :at 1521045599945, :text "24", :id "Bymvvx08tz"}
-                  }
-                 }
-                 "r" {
-                  :type :expr, :by "root", :at 1521045600706, :id "BygFvgA8Kf"
-                  :data {
-                   "T" {:type :leaf, :by "root", :at 1521045603448, :text ":font-family", :id "BygFvgA8Kfleaf"}
-                   "j" {:type :leaf, :by "root", :at 1521045625668, :text "ui/font-fancy", :id "SJBjwx08tG"}
-                  }
-                 }
-                 "v" {
-                  :type :expr, :by "root", :at 1521045612555, :id "SJBde08tG"
-                  :data {
-                   "T" {:type :leaf, :by "root", :at 1521045618980, :text ":font-weight", :id "SJBde08tGleaf"}
-                   "j" {:type :leaf, :by "root", :at 1521045619562, :text "100", :id "HyMiuxCLYz"}
-                  }
-                 }
-                }
-               }
-              }
-             }
-             "t" {
-              :type :expr, :by "root", :at 1530033364160, :id "r1x204lefm"
-              :data {
-               "T" {:type :leaf, :by "root", :at 1530033364940, :text "=<", :id "r1x204lefmleaf"}
-               "b" {:type :leaf, :by "root", :at 1530033367472, :text "16", :id "BJ1yBxeGm"}
-               "j" {:type :leaf, :by "root", :at 1530033365718, :text "nil", :id "By-a0Elxfm"}
-              }
-             }
-             "v" {
-              :type :expr, :by "root", :at 1530033145124, :id "ryuANleG7"
-              :data {
-               "T" {:type :leaf, :by "root", :at 1530033148215, :text "if", :id "SJxZ-NxgfXleaf"}
-               "j" {
-                :type :expr, :by "root", :at 1530033149128, :id "SkxSbEexfQ"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1530033151343, :text ":editing?", :id "SJS-4exMm"}
-                 "j" {:type :leaf, :by "root", :at 1530033152482, :text "state", :id "rkObVxxfX"}
-                }
-               }
-               "r" {
-                :type :expr, :by "root", :at 1530033155428, :id "rylsWVelGX"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1530033374782, :text "a", :id "rylsWVelGXleaf"}
-                 "j" {
-                  :type :expr, :by "root", :at 1530033157937, :id "BylAZ4lxMX"
-                  :data {
-                   "T" {:type :leaf, :by "root", :at 1530033158309, :text "{}", :id "Sy0bVgefQ"}
-                   "j" {
-                    :type :expr, :by "root", :at 1530033159865, :id "rJlefEexfQ"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1530033162660, :text ":style", :id "HJlGVelM7"}
-                     "j" {:type :leaf, :by "root", :at 1530033376921, :text "ui/link", :id "r1emfElgfQ"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "root", :at 1530033170079, :id "BJ5MVlxzQ"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1530033173693, :text ":inner-text", :id "BJ5MVlxzQleaf"}
-                     "j" {:type :leaf, :by "root", :at 1530033272118, :text "\"Done", :id "SklRfVlefQ"}
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "root", :at 1530033196274, :id "rkeVNVexM7"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1530033199223, :text ":on-click", :id "rkeVNVexM7leaf"}
-                     "j" {
-                      :type :expr, :by "root", :at 1530033199674, :id "SJO4Velzm"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1530033230414, :text "mutation->", :id "ryLw4VgeG7"}
-                       "j" {
-                        :type :expr, :by "root", :at 1530033205932, :id "B1x0E4xlGQ"
-                        :data {
-                         "T" {:type :leaf, :by "root", :at 1530033208939, :text "update", :id "S1CNNlefm"}
-                         "j" {:type :leaf, :by "root", :at 1530033209530, :text "state", :id "rJG-rEegzX"}
-                         "r" {:type :leaf, :by "root", :at 1530033212256, :text ":editing?", :id "rygfHExlfX"}
-                         "v" {:type :leaf, :by "root", :at 1530033214332, :text "not", :id "BJmEHNxeMX"}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-               "v" {
-                :type :expr, :by "root", :at 1530033155428, :id "BJxw7VlgGX"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1530033378207, :text "a", :id "rylsWVelGXleaf"}
-                 "j" {
-                  :type :expr, :by "root", :at 1530033157937, :id "BylAZ4lxMX"
-                  :data {
-                   "T" {:type :leaf, :by "root", :at 1530033158309, :text "{}", :id "Sy0bVgefQ"}
-                   "j" {
-                    :type :expr, :by "root", :at 1530033159865, :id "rJlefEexfQ"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1530033162660, :text ":style", :id "HJlGVelM7"}
-                     "j" {:type :leaf, :by "root", :at 1530033380055, :text "ui/link", :id "r1emfElgfQ"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :by "root", :at 1530033170079, :id "BJ5MVlxzQ"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1530033173693, :text ":inner-text", :id "BJ5MVlxzQleaf"}
-                     "j" {:type :leaf, :by "root", :at 1530033270166, :text "\"Edit", :id "SklRfVlefQ"}
-                    }
-                   }
-                   "v" {
-                    :type :expr, :by "root", :at 1530033217977, :id "Ske9BNexGQ"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1530033219848, :text ":on-click", :id "Ske9BNexGQleaf"}
-                     "j" {
-                      :type :expr, :by "root", :at 1530033199674, :id "H1znrNggfm"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1530033232250, :text "mutation->", :id "ryLw4VgeG7"}
-                       "j" {
-                        :type :expr, :by "root", :at 1530033205932, :id "B1x0E4xlGQ"
-                        :data {
-                         "T" {:type :leaf, :by "root", :at 1530033208939, :text "update", :id "S1CNNlefm"}
-                         "j" {:type :leaf, :by "root", :at 1530033209530, :text "state", :id "rJG-rEegzX"}
-                         "r" {:type :leaf, :by "root", :at 1530033212256, :text ":editing?", :id "rygfHExlfX"}
-                         "v" {:type :leaf, :by "root", :at 1530033214332, :text "not", :id "BJmEHNxeMX"}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
                   }
                  }
                 }
@@ -2372,201 +2191,135 @@
             }
            }
            "v" {
-            :type :expr, :by "root", :at 1531642530659, :id "rJjofKuX7"
+            :type :expr, :by "root", :at 1531642535246, :id "SyZJnfYdXQ"
             :data {
-             "D" {:type :leaf, :by "root", :at 1531642531464, :text "div", :id "B1gssfKumQ"}
-             "L" {
-              :type :expr, :by "root", :at 1531642531667, :id "Bke2iGFum7"
+             "T" {:type :leaf, :by "root", :at 1531642550829, :text "list->", :id "SyZJnfYdXQleaf"}
+             "j" {
+              :type :expr, :by "root", :at 1531642551111, :id "S1z1aMFu77"
               :data {
-               "T" {:type :leaf, :by "root", :at 1531642532047, :text "{}", :id "HJ3ozFumm"}
+               "T" {:type :leaf, :by "root", :at 1531642552367, :text "{}", :id "SJZJpztOXQ"}
                "j" {
-                :type :expr, :by "root", :at 1531642532583, :id "BJaofF_7Q"
+                :type :expr, :by "root", :at 1531642614659, :id "Sk1Z7KuQm"
                 :data {
-                 "T" {:type :leaf, :by "root", :at 1531642533312, :text ":style", :id "r17hifFOmm"}
-                 "j" {:type :leaf, :by "root", :at 1531642534260, :text "ui/row", :id "By8TiGYO77"}
-                }
-               }
-              }
-             }
-             "P" {
-              :type :expr, :by "root", :at 1531642535246, :id "SyZJnfYdXQ"
-              :data {
-               "T" {:type :leaf, :by "root", :at 1531642550829, :text "list->", :id "SyZJnfYdXQleaf"}
-               "j" {
-                :type :expr, :by "root", :at 1531642551111, :id "S1z1aMFu77"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1531642552367, :text "{}", :id "SJZJpztOXQ"}
-                 "j" {
-                  :type :expr, :by "root", :at 1531642614659, :id "Sk1Z7KuQm"
+                 "D" {:type :leaf, :by "root", :at 1531642615790, :text ":style", :id "Hyx1-XtuXm"}
+                 "T" {
+                  :type :expr, :by "root", :at 1531642612097, :id "S1ZnxQK_7Q"
                   :data {
-                   "D" {:type :leaf, :by "root", :at 1531642615790, :text ":style", :id "Hyx1-XtuXm"}
+                   "D" {:type :leaf, :by "root", :at 1531642612662, :text "{}", :id "Bkz2eQKdQ7"}
                    "T" {
-                    :type :expr, :by "root", :at 1531642612097, :id "S1ZnxQK_7Q"
+                    :type :expr, :by "root", :at 1531642613083, :id "r1G6lXFdXQ"
                     :data {
-                     "D" {:type :leaf, :by "root", :at 1531642612662, :text "{}", :id "Bkz2eQKdQ7"}
-                     "T" {
-                      :type :expr, :by "root", :at 1531642613083, :id "r1G6lXFdXQ"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1531642606655, :text ":overflow", :id "HkxBlQtuXQ"}
-                       "j" {:type :leaf, :by "root", :at 1531642607705, :text ":auto", :id "SJWPlXF_7m"}
-                      }
-                     }
-                     "j" {
-                      :type :expr, :by "root", :at 1531642618515, :id "H1GGb7td7m"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1531642633949, :text ":font-family", :id "H1GGb7td7mleaf"}
-                       "j" {:type :leaf, :by "root", :at 1531642638221, :text "ui/font-fancy", :id "r1GfzQtumX"}
-                      }
-                     }
-                     "r" {
-                      :type :expr, :by "root", :at 1531642647079, :id "r1lymQtOXX"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1531642648766, :text ":max-height", :id "r1lymQtOXXleaf"}
-                       "j" {:type :leaf, :by "root", :at 1531642651402, :text "320", :id "SkfZmmtum7"}
-                      }
-                     }
+                     "T" {:type :leaf, :by "root", :at 1531642606655, :text ":overflow", :id "HkxBlQtuXQ"}
+                     "j" {:type :leaf, :by "root", :at 1531642607705, :text ":auto", :id "SJWPlXF_7m"}
+                    }
+                   }
+                   "j" {
+                    :type :expr, :by "root", :at 1531642618515, :id "H1GGb7td7m"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1531642633949, :text ":font-family", :id "H1GGb7td7mleaf"}
+                     "j" {:type :leaf, :by "root", :at 1531642638221, :text "ui/font-fancy", :id "r1GfzQtumX"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "root", :at 1531642647079, :id "r1lymQtOXX"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1531642648766, :text ":max-height", :id "r1lymQtOXXleaf"}
+                     "j" {:type :leaf, :by "root", :at 1531642651402, :text "320", :id "SkfZmmtum7"}
                     }
                    }
                   }
                  }
                 }
                }
+              }
+             }
+             "r" {
+              :type :expr, :by "root", :at 1531642553148, :id "Skg-pftOQm"
+              :data {
+               "T" {:type :leaf, :by "root", :at 1531642557729, :text "->>", :id "Skg-pftOQmleaf"}
+               "f" {:type :leaf, :by "root", :at 1531642791032, :text "months", :id "By0jQYdQm"}
                "r" {
-                :type :expr, :by "root", :at 1531642553148, :id "Skg-pftOQm"
+                :type :expr, :by "root", :at 1531642566612, :id "Skk0zF_77"
                 :data {
-                 "T" {:type :leaf, :by "root", :at 1531642557729, :text "->>", :id "Skg-pftOQmleaf"}
-                 "f" {:type :leaf, :by "root", :at 1531642791032, :text "months", :id "By0jQYdQm"}
-                 "r" {
-                  :type :expr, :by "root", :at 1531642566612, :id "Skk0zF_77"
+                 "T" {:type :leaf, :by "root", :at 1531642567533, :text "map", :id "rkC6MKO7X"}
+                 "j" {
+                  :type :expr, :by "root", :at 1531642568135, :id "rJ-xRMt_QX"
                   :data {
-                   "T" {:type :leaf, :by "root", :at 1531642567533, :text "map", :id "rkC6MKO7X"}
+                   "T" {:type :leaf, :by "root", :at 1531642572530, :text "fn", :id "rJglCGtumm"}
                    "j" {
-                    :type :expr, :by "root", :at 1531642568135, :id "rJ-xRMt_QX"
+                    :type :expr, :by "root", :at 1531642572798, :id "rk-HCMYdm7"
                     :data {
-                     "T" {:type :leaf, :by "root", :at 1531642572530, :text "fn", :id "rJglCGtumm"}
-                     "j" {
-                      :type :expr, :by "root", :at 1531642572798, :id "rk-HCMYdm7"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1531642575563, :text "year-month", :id "HJxHRfKOm7"}
-                      }
-                     }
+                     "T" {:type :leaf, :by "root", :at 1531642575563, :text "year-month", :id "HJxHRfKOm7"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "root", :at 1531642576654, :id "H1t0MFuX7"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1531642577371, :text "[]", :id "H1t0MFuX7leaf"}
+                     "j" {:type :leaf, :by "root", :at 1531642577790, :text "year-month", :id "r1MK0GK_77"}
                      "r" {
-                      :type :expr, :by "root", :at 1531642576654, :id "H1t0MFuX7"
+                      :type :expr, :by "root", :at 1531642578232, :id "S1-5CMYumX"
                       :data {
-                       "T" {:type :leaf, :by "root", :at 1531642577371, :text "[]", :id "H1t0MFuX7leaf"}
-                       "j" {:type :leaf, :by "root", :at 1531642577790, :text "year-month", :id "r1MK0GK_77"}
-                       "r" {
-                        :type :expr, :by "root", :at 1531642578232, :id "S1-5CMYumX"
+                       "T" {:type :leaf, :by "root", :at 1531642580991, :text "div", :id "Sk30zKuQQ"}
+                       "j" {
+                        :type :expr, :by "root", :at 1531642581213, :id "B1Xp0MYdmm"
                         :data {
-                         "T" {:type :leaf, :by "root", :at 1531642580991, :text "div", :id "Sk30zKuQQ"}
+                         "T" {:type :leaf, :by "root", :at 1531642581560, :text "{}", :id "HyfaRMKOmX"}
                          "j" {
-                          :type :expr, :by "root", :at 1531642581213, :id "B1Xp0MYdmm"
+                          :type :expr, :by "root", :at 1531642728237, :id "r1xdXt_7m"
                           :data {
-                           "T" {:type :leaf, :by "root", :at 1531642581560, :text "{}", :id "HyfaRMKOmX"}
+                           "T" {:type :leaf, :by "root", :at 1531642730045, :text ":style", :id "HJxpwmKu7Q"}
                            "j" {
-                            :type :expr, :by "root", :at 1531642728237, :id "r1xdXt_7m"
+                            :type :expr, :by "root", :at 1531642736472, :id "B1dO7F_Q7"
                             :data {
-                             "T" {:type :leaf, :by "root", :at 1531642730045, :text ":style", :id "HJxpwmKu7Q"}
-                             "j" {
-                              :type :expr, :by "root", :at 1531642736472, :id "B1dO7F_Q7"
+                             "D" {:type :leaf, :by "root", :at 1531642737532, :text "merge", :id "SJF_7tdmQ"}
+                             "T" {
+                              :type :expr, :by "root", :at 1531642730352, :id "rJBG_XtO7X"
                               :data {
-                               "D" {:type :leaf, :by "root", :at 1531642737532, :text "merge", :id "SJF_7tdmQ"}
-                               "T" {
-                                :type :expr, :by "root", :at 1531642730352, :id "rJBG_XtO7X"
+                               "T" {:type :leaf, :by "root", :at 1531642730915, :text "{}", :id "S1NGuQFd7m"}
+                               "j" {
+                                :type :expr, :by "root", :at 1531642731786, :id "B1xEdXK_XX"
                                 :data {
-                                 "T" {:type :leaf, :by "root", :at 1531642730915, :text "{}", :id "S1NGuQFd7m"}
-                                 "j" {
-                                  :type :expr, :by "root", :at 1531642731786, :id "B1xEdXK_XX"
-                                  :data {
-                                   "T" {:type :leaf, :by "root", :at 1531642733199, :text ":cursor", :id "BkV_XKOXX"}
-                                   "j" {:type :leaf, :by "root", :at 1531642734543, :text ":pointer", :id "Bk-B_7YuXQ"}
-                                  }
-                                 }
-                                 "r" {
-                                  :type :expr, :by "root", :at 1531642917644, :id "SkA7EFO7X"
-                                  :data {
-                                   "T" {:type :leaf, :by "root", :at 1531642919347, :text ":padding", :id "SkA7EFO7Xleaf"}
-                                   "j" {:type :leaf, :by "root", :at 1531642931317, :text "\"0 18px", :id "SkmJ44KdXm"}
-                                  }
-                                 }
+                                 "T" {:type :leaf, :by "root", :at 1531642733199, :text ":cursor", :id "BkV_XKOXX"}
+                                 "j" {:type :leaf, :by "root", :at 1531642734543, :text ":pointer", :id "Bk-B_7YuXQ"}
                                 }
                                }
-                               "j" {
-                                :type :expr, :by "root", :at 1531642739209, :id "BJliOmYdQm"
+                               "r" {
+                                :type :expr, :by "root", :at 1531642917644, :id "SkA7EFO7X"
                                 :data {
-                                 "T" {:type :leaf, :by "root", :at 1531642749577, :text "when", :id "HyWcOQYOXm"}
-                                 "j" {
-                                  :type :expr, :by "root", :at 1531642740721, :id "B1x6d7YuQm"
-                                  :data {
-                                   "D" {:type :leaf, :by "root", :at 1531642742068, :text "=", :id "B1eROQYuQX"}
-                                   "T" {:type :leaf, :by "root", :at 1531642741611, :text "cursor", :id "rkWsOQKu7m"}
-                                   "j" {:type :leaf, :by "root", :at 1531642746997, :text "year-month", :id "H1QCO7YOmQ"}
-                                  }
-                                 }
-                                 "r" {
-                                  :type :expr, :by "root", :at 1531642750372, :id "ryM8Y7KdXX"
-                                  :data {
-                                   "T" {:type :leaf, :by "root", :at 1531642751125, :text "{}", :id "ryM8Y7KdXXleaf"}
-                                   "j" {
-                                    :type :expr, :by "root", :at 1531642751637, :id "BkuFXY_Q7"
-                                    :data {
-                                     "T" {:type :leaf, :by "root", :at 1531642761808, :text ":background-color", :id "HkbPt7F_m7"}
-                                     "j" {
-                                      :type :expr, :by "root", :at 1531642934330, :id "Hk-0N4FdXX"
-                                      :data {
-                                       "T" {:type :leaf, :by "root", :at 1531642934939, :text "hsl", :id "r1Zfq7Y_XX"}
-                                       "j" {:type :leaf, :by "root", :at 1531642935673, :text "0", :id "r1GJrVYdQX"}
-                                       "r" {:type :leaf, :by "root", :at 1531642936037, :text "0", :id "rkxlB4Yumm"}
-                                       "v" {:type :leaf, :by "root", :at 1531642936454, :text "90", :id "BJMxBEt_mm"}
-                                      }
-                                     }
-                                    }
-                                   }
-                                  }
-                                 }
+                                 "T" {:type :leaf, :by "root", :at 1531642919347, :text ":padding", :id "SkA7EFO7Xleaf"}
+                                 "j" {:type :leaf, :by "root", :at 1531642931317, :text "\"0 18px", :id "SkmJ44KdXm"}
                                 }
                                }
                               }
                              }
-                            }
-                           }
-                           "r" {
-                            :type :expr, :by "root", :at 1531642825155, :id "SklZRXY_m7"
-                            :data {
-                             "T" {:type :leaf, :by "root", :at 1531642827279, :text ":on-click", :id "SklZRXY_m7leaf"}
                              "j" {
-                              :type :expr, :by "root", :at 1531642827571, :id "S1VCmtu7X"
+                              :type :expr, :by "root", :at 1531642739209, :id "BJliOmYdQm"
                               :data {
-                               "T" {:type :leaf, :by "root", :at 1531642828493, :text "fn", :id "ryHQ07F_mX"}
+                               "T" {:type :leaf, :by "root", :at 1531642749577, :text "when", :id "HyWcOQYOXm"}
                                "j" {
-                                :type :expr, :by "root", :at 1531642828798, :id "SkeH0XYdmX"
+                                :type :expr, :by "root", :at 1531642740721, :id "B1x6d7YuQm"
                                 :data {
-                                 "T" {:type :leaf, :by "root", :at 1531642829002, :text "e", :id "SkrR7KOmm"}
-                                 "j" {:type :leaf, :by "root", :at 1531642831016, :text "d!", :id "S1zSCQFd7Q"}
-                                 "r" {:type :leaf, :by "root", :at 1531642831666, :text "m!", :id "H1-w0XF_QQ"}
+                                 "D" {:type :leaf, :by "root", :at 1531642742068, :text "=", :id "B1eROQYuQX"}
+                                 "T" {:type :leaf, :by "root", :at 1531642741611, :text "cursor", :id "rkWsOQKu7m"}
+                                 "j" {:type :leaf, :by "root", :at 1531642746997, :text "year-month", :id "H1QCO7YOmQ"}
                                 }
                                }
                                "r" {
-                                :type :expr, :by "root", :at 1531642832179, :id "B1WO0QFOQ7"
+                                :type :expr, :by "root", :at 1531642750372, :id "ryM8Y7KdXX"
                                 :data {
-                                 "T" {:type :leaf, :by "root", :at 1531642833025, :text "d!", :id "B1WO0QFOQ7leaf"}
-                                 "j" {:type :leaf, :by "root", :at 1531642835860, :text ":router/change", :id "HyetRmFu77"}
-                                 "r" {
-                                  :type :expr, :by "root", :at 1531642836076, :id "ByE2AXK_XQ"
+                                 "T" {:type :leaf, :by "root", :at 1531642751125, :text "{}", :id "ryM8Y7KdXXleaf"}
+                                 "j" {
+                                  :type :expr, :by "root", :at 1531642751637, :id "BkuFXY_Q7"
                                   :data {
-                                   "T" {:type :leaf, :by "root", :at 1531642836477, :text "{}", :id "Symn0XtOQX"}
+                                   "T" {:type :leaf, :by "root", :at 1531642761808, :text ":background-color", :id "HkbPt7F_m7"}
                                    "j" {
-                                    :type :expr, :by "root", :at 1531642836671, :id "ryg60QYdQ7"
+                                    :type :expr, :by "root", :at 1531642934330, :id "Hk-0N4FdXX"
                                     :data {
-                                     "T" {:type :leaf, :by "root", :at 1531642837306, :text ":name", :id "B1aCXKO7Q"}
-                                     "j" {:type :leaf, :by "root", :at 1531642848803, :text ":done", :id "SkIpCXtOQ7"}
-                                    }
-                                   }
-                                   "r" {
-                                    :type :expr, :by "root", :at 1531642849562, :id "BycJNtd7X"
-                                    :data {
-                                     "T" {:type :leaf, :by "root", :at 1531642850316, :text ":data", :id "BycJNtd7Xleaf"}
-                                     "j" {:type :leaf, :by "root", :at 1531642853674, :text "year-month", :id "BJHqyEKuQm"}
+                                     "T" {:type :leaf, :by "root", :at 1531642934939, :text "hsl", :id "r1Zfq7Y_XX"}
+                                     "j" {:type :leaf, :by "root", :at 1531642935673, :text "0", :id "r1GJrVYdQX"}
+                                     "r" {:type :leaf, :by "root", :at 1531642936037, :text "0", :id "rkxlB4Yumm"}
+                                     "v" {:type :leaf, :by "root", :at 1531642936454, :text "90", :id "BJMxBEt_mm"}
                                     }
                                    }
                                   }
@@ -2580,12 +2333,59 @@
                           }
                          }
                          "r" {
-                          :type :expr, :by "root", :at 1531642582196, :id "rk-0AGYuQX"
+                          :type :expr, :by "root", :at 1531642825155, :id "SklZRXY_m7"
                           :data {
-                           "T" {:type :leaf, :by "root", :at 1531642582537, :text "<>", :id "rk-0AGYuQXleaf"}
-                           "j" {:type :leaf, :by "root", :at 1531642582993, :text "year-month", :id "ryl1kXYumX"}
+                           "T" {:type :leaf, :by "root", :at 1531642827279, :text ":on-click", :id "SklZRXY_m7leaf"}
+                           "j" {
+                            :type :expr, :by "root", :at 1531642827571, :id "S1VCmtu7X"
+                            :data {
+                             "T" {:type :leaf, :by "root", :at 1531642828493, :text "fn", :id "ryHQ07F_mX"}
+                             "j" {
+                              :type :expr, :by "root", :at 1531642828798, :id "SkeH0XYdmX"
+                              :data {
+                               "T" {:type :leaf, :by "root", :at 1531642829002, :text "e", :id "SkrR7KOmm"}
+                               "j" {:type :leaf, :by "root", :at 1531642831016, :text "d!", :id "S1zSCQFd7Q"}
+                               "r" {:type :leaf, :by "root", :at 1531642831666, :text "m!", :id "H1-w0XF_QQ"}
+                              }
+                             }
+                             "r" {
+                              :type :expr, :by "root", :at 1531642832179, :id "B1WO0QFOQ7"
+                              :data {
+                               "T" {:type :leaf, :by "root", :at 1531642833025, :text "d!", :id "B1WO0QFOQ7leaf"}
+                               "j" {:type :leaf, :by "root", :at 1531642835860, :text ":router/change", :id "HyetRmFu77"}
+                               "r" {
+                                :type :expr, :by "root", :at 1531642836076, :id "ByE2AXK_XQ"
+                                :data {
+                                 "T" {:type :leaf, :by "root", :at 1531642836477, :text "{}", :id "Symn0XtOQX"}
+                                 "j" {
+                                  :type :expr, :by "root", :at 1531642836671, :id "ryg60QYdQ7"
+                                  :data {
+                                   "T" {:type :leaf, :by "root", :at 1531642837306, :text ":name", :id "B1aCXKO7Q"}
+                                   "j" {:type :leaf, :by "root", :at 1531642848803, :text ":done", :id "SkIpCXtOQ7"}
+                                  }
+                                 }
+                                 "r" {
+                                  :type :expr, :by "root", :at 1531642849562, :id "BycJNtd7X"
+                                  :data {
+                                   "T" {:type :leaf, :by "root", :at 1531642850316, :text ":data", :id "BycJNtd7Xleaf"}
+                                   "j" {:type :leaf, :by "root", :at 1531642853674, :text "year-month", :id "BJHqyEKuQm"}
+                                  }
+                                 }
+                                }
+                               }
+                              }
+                             }
+                            }
+                           }
                           }
                          }
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "root", :at 1531642582196, :id "rk-0AGYuQX"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1531642582537, :text "<>", :id "rk-0AGYuQXleaf"}
+                         "j" {:type :leaf, :by "root", :at 1531642582993, :text "year-month", :id "ryl1kXYumX"}
                         }
                        }
                       }
@@ -2598,12 +2398,206 @@
                }
               }
              }
-             "R" {
-              :type :expr, :by "root", :at 1531642590470, :id "HklUkmYdXm"
+            }
+           }
+           "w" {
+            :type :expr, :by "root", :at 1531642590470, :id "HyJzDt_mQ"
+            :data {
+             "T" {:type :leaf, :by "root", :at 1531642596555, :text "=<", :id "HklUkmYdXmleaf"}
+             "j" {:type :leaf, :by "root", :at 1531642597235, :text "16", :id "H1xpJ7F_QX"}
+             "r" {:type :leaf, :by "root", :at 1531642598161, :text "nil", :id "H1CyXtuXQ"}
+            }
+           }
+           "wT" {
+            :type :expr, :by "root", :at 1531643620427, :id "B1nyvY_Q7"
+            :data {
+             "D" {:type :leaf, :by "root", :at 1531643621504, :text "div", :id "Bygp1PFdm7"}
+             "L" {
+              :type :expr, :by "root", :at 1531643621734, :id "HyxR1DtuQm"
               :data {
-               "T" {:type :leaf, :by "root", :at 1531642596555, :text "=<", :id "HklUkmYdXmleaf"}
-               "j" {:type :leaf, :by "root", :at 1531642597235, :text "16", :id "H1xpJ7F_QX"}
-               "r" {:type :leaf, :by "root", :at 1531642598161, :text "nil", :id "H1CyXtuXQ"}
+               "T" {:type :leaf, :by "root", :at 1531643622118, :text "{}", :id "ryR1vtumm"}
+               "j" {
+                :type :expr, :by "root", :at 1531643622627, :id "r1JxPF_77"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1531643625491, :text ":style", :id "rJXCkwKdXX"}
+                 "j" {:type :leaf, :by "root", :at 1531643628213, :text "ui/column", :id "SJzxwYdmm"}
+                }
+               }
+              }
+             }
+             "P" {
+              :type :expr, :by "root", :at 1521045551385, :id "SJl0lPY_QQ"
+              :data {
+               "T" {:type :leaf, :by "root", :at 1521045552182, :text "div", :id "r1fIEeA8Kz"}
+               "j" {
+                :type :expr, :by "root", :at 1521045552483, :id "BkM_ExRIYM"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1521045552817, :text "{}", :id "B1-u4gCIFM"}
+                }
+               }
+               "r" {
+                :type :expr, :by "root", :at 1521132750884, :id "r1lPAE7uYG"
+                :data {
+                 "D" {:type :leaf, :by "root", :at 1521132751621, :text "<>", :id "r1bwCV7dYf"}
+                 "T" {
+                  :type :expr, :by "root", :at 1521045553893, :id "rylcNxR8KG"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1521132750289, :text "str", :id "rylcNxR8KGleaf"}
+                   "j" {:type :leaf, :by "root", :at 1531643563714, :text "|Done Tasks(", :id "BJfhNxCLKz"}
+                   "n" {
+                    :type :expr, :by "root", :at 1531643568035, :id "SJOh8Y_7Q"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1531643568693, :text "count", :id "r1P2LYuQX"}
+                     "j" {:type :leaf, :by "root", :at 1531643569494, :text "tasks", :id "BJbY2IYOX7"}
+                    }
+                   }
+                   "r" {:type :leaf, :by "root", :at 1531643566177, :text "\")", :id "rkgN3IYuQm"}
+                  }
+                 }
+                 "j" {
+                  :type :expr, :by "root", :at 1521045597163, :id "rJQBDgRLKz"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1521045597485, :text "{}", :id "HJfBPxRUKM"}
+                   "j" {
+                    :type :expr, :by "root", :at 1521045597703, :id "BklIveRUKf"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1521045599185, :text ":font-size", :id "H18PgAUFG"}
+                     "j" {:type :leaf, :by "root", :at 1521045599945, :text "24", :id "Bymvvx08tz"}
+                    }
+                   }
+                   "r" {
+                    :type :expr, :by "root", :at 1521045600706, :id "BygFvgA8Kf"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1521045603448, :text ":font-family", :id "BygFvgA8Kfleaf"}
+                     "j" {:type :leaf, :by "root", :at 1521045625668, :text "ui/font-fancy", :id "SJBjwx08tG"}
+                    }
+                   }
+                   "v" {
+                    :type :expr, :by "root", :at 1521045612555, :id "SJBde08tG"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1521045618980, :text ":font-weight", :id "SJBde08tGleaf"}
+                     "j" {:type :leaf, :by "root", :at 1521045619562, :text "100", :id "HyMiuxCLYz"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "t" {
+                :type :expr, :by "root", :at 1530033364160, :id "r1x204lefm"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1530033364940, :text "=<", :id "r1x204lefmleaf"}
+                 "b" {:type :leaf, :by "root", :at 1530033367472, :text "16", :id "BJ1yBxeGm"}
+                 "j" {:type :leaf, :by "root", :at 1530033365718, :text "nil", :id "By-a0Elxfm"}
+                }
+               }
+               "v" {
+                :type :expr, :by "root", :at 1530033145124, :id "ryuANleG7"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1530033148215, :text "if", :id "SJxZ-NxgfXleaf"}
+                 "j" {
+                  :type :expr, :by "root", :at 1530033149128, :id "SkxSbEexfQ"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1530033151343, :text ":editing?", :id "SJS-4exMm"}
+                   "j" {:type :leaf, :by "root", :at 1530033152482, :text "state", :id "rkObVxxfX"}
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "root", :at 1530033155428, :id "rylsWVelGX"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1530033374782, :text "a", :id "rylsWVelGXleaf"}
+                   "j" {
+                    :type :expr, :by "root", :at 1530033157937, :id "BylAZ4lxMX"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1530033158309, :text "{}", :id "Sy0bVgefQ"}
+                     "j" {
+                      :type :expr, :by "root", :at 1530033159865, :id "rJlefEexfQ"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1530033162660, :text ":style", :id "HJlGVelM7"}
+                       "j" {:type :leaf, :by "root", :at 1530033376921, :text "ui/link", :id "r1emfElgfQ"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "root", :at 1530033170079, :id "BJ5MVlxzQ"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1530033173693, :text ":inner-text", :id "BJ5MVlxzQleaf"}
+                       "j" {:type :leaf, :by "root", :at 1530033272118, :text "\"Done", :id "SklRfVlefQ"}
+                      }
+                     }
+                     "v" {
+                      :type :expr, :by "root", :at 1530033196274, :id "rkeVNVexM7"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1530033199223, :text ":on-click", :id "rkeVNVexM7leaf"}
+                       "j" {
+                        :type :expr, :by "root", :at 1530033199674, :id "SJO4Velzm"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1530033230414, :text "mutation->", :id "ryLw4VgeG7"}
+                         "j" {
+                          :type :expr, :by "root", :at 1530033205932, :id "B1x0E4xlGQ"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1530033208939, :text "update", :id "S1CNNlefm"}
+                           "j" {:type :leaf, :by "root", :at 1530033209530, :text "state", :id "rJG-rEegzX"}
+                           "r" {:type :leaf, :by "root", :at 1530033212256, :text ":editing?", :id "rygfHExlfX"}
+                           "v" {:type :leaf, :by "root", :at 1530033214332, :text "not", :id "BJmEHNxeMX"}
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "v" {
+                  :type :expr, :by "root", :at 1530033155428, :id "BJxw7VlgGX"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1530033378207, :text "a", :id "rylsWVelGXleaf"}
+                   "j" {
+                    :type :expr, :by "root", :at 1530033157937, :id "BylAZ4lxMX"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1530033158309, :text "{}", :id "Sy0bVgefQ"}
+                     "j" {
+                      :type :expr, :by "root", :at 1530033159865, :id "rJlefEexfQ"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1530033162660, :text ":style", :id "HJlGVelM7"}
+                       "j" {:type :leaf, :by "root", :at 1530033380055, :text "ui/link", :id "r1emfElgfQ"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :by "root", :at 1530033170079, :id "BJ5MVlxzQ"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1530033173693, :text ":inner-text", :id "BJ5MVlxzQleaf"}
+                       "j" {:type :leaf, :by "root", :at 1530033270166, :text "\"Edit", :id "SklRfVlefQ"}
+                      }
+                     }
+                     "v" {
+                      :type :expr, :by "root", :at 1530033217977, :id "Ske9BNexGQ"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1530033219848, :text ":on-click", :id "Ske9BNexGQleaf"}
+                       "j" {
+                        :type :expr, :by "root", :at 1530033199674, :id "H1znrNggfm"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1530033232250, :text "mutation->", :id "ryLw4VgeG7"}
+                         "j" {
+                          :type :expr, :by "root", :at 1530033205932, :id "B1x0E4xlGQ"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1530033208939, :text "update", :id "S1CNNlefm"}
+                           "j" {:type :leaf, :by "root", :at 1530033209530, :text "state", :id "rJG-rEegzX"}
+                           "r" {:type :leaf, :by "root", :at 1530033212256, :text ":editing?", :id "rygfHExlfX"}
+                           "v" {:type :leaf, :by "root", :at 1530033214332, :text "not", :id "BJmEHNxeMX"}
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
               }
              }
              "T" {

--- a/calcit.edn
+++ b/calcit.edn
@@ -951,8 +951,8 @@
                   :data {
                    "T" {:type :leaf, :id "SktwcIxlCS-", :text "merge", :by "root", :at 1500541010211}
                    "j" {:type :leaf, :id "Hk9PqUlg0Bb", :text "ui/global", :by "root", :at 1500541010211}
-                   "r" {:type :leaf, :id "HkjD9Lel0B-", :text "ui/fullscreen", :by "root", :at 1500541010211}
-                   "v" {:type :leaf, :id "SJ3vcUegASZ", :text "ui/row", :by "root", :at 1520874750185}
+                   "p" {:type :leaf, :by "root", :at 1531641001105, :text "ui/fullscreen", :id "HkCo2Odm7"}
+                   "v" {:type :leaf, :id "SJ3vcUegASZ", :text "ui/column", :by "root", :at 1531640710080}
                   }
                  }
                 }
@@ -962,7 +962,7 @@
              "r" {
               :type :expr, :id "r1pw9LelCr-", :by nil, :at 1500541010211
               :data {
-               "T" {:type :leaf, :id "SyAvc8lgCB-", :text "comp-sidebar", :by "root", :at 1520874704583}
+               "T" {:type :leaf, :id "SyAvc8lgCB-", :text "comp-sidebar", :by "root", :at 1531640824563}
                "b" {
                 :type :expr, :by "root", :at 1520961748118, :id "Skg2RuFrYM"
                 :data {
@@ -987,128 +987,205 @@
               }
              }
              "v" {
-              :type :expr, :id "rkXYc8ll0SW", :by nil, :at 1500541010211
+              :type :expr, :by "root", :at 1531641022324, :id "H1Lp2udXQ"
               :data {
-               "T" {:type :leaf, :id "HJVYcUxlRrZ", :text "if", :by "root", :at 1500541010211}
-               "j" {
-                :type :expr, :id "S1rK5UggABZ", :by nil, :at 1500541010211
+               "D" {:type :leaf, :by "root", :at 1531641023137, :text "div", :id "Sywa3O_7X"}
+               "L" {
+                :type :expr, :by "root", :at 1531641023395, :id "B1Nw63_umQ"
                 :data {
-                 "T" {:type :leaf, :id "rkUtqUxg0HZ", :text ":logged-in?", :by "root", :at 1500541010211}
-                 "j" {:type :leaf, :id "r1Dtq8lxArb", :text "store", :by "root", :at 1500541010211}
-                }
-               }
-               "r" {
-                :type :expr, :id "B1dK5UggRBW", :by nil, :at 1500541010211
-                :data {
-                 "T" {:type :leaf, :id "H1FFc8lx0Hb", :text "let", :by "root", :at 1500541010211}
+                 "T" {:type :leaf, :by "root", :at 1531641023742, :text "{}", :id "Bkmv6hudX7"}
                  "j" {
-                  :type :expr, :id "r1qFcIglRrb", :by nil, :at 1500541010211
+                  :type :expr, :by "root", :at 1531641024674, :id "BytTn_uQm"
                   :data {
-                   "T" {
-                    :type :expr, :id "HyjK5UxgAr-", :by nil, :at 1500541010211
+                   "T" {:type :leaf, :by "root", :at 1531641026255, :text ":style", :id "r1WuanOdmm"}
+                   "j" {
+                    :type :expr, :by "root", :at 1531641037411, :id "SyeSA2udQ7"
                     :data {
-                     "T" {:type :leaf, :id "B12tqUxlASZ", :text "router", :by "root", :at 1500541010211}
+                     "T" {:type :leaf, :by "root", :at 1531641037743, :text "{}", :id "SJSA3dO7X"}
                      "j" {
-                      :type :expr, :id "HJ6Fc8xeRHW", :by nil, :at 1500541010211
+                      :type :expr, :by "root", :at 1531641088880, :id "rJxFbT_dXm"
                       :data {
-                       "T" {:type :leaf, :id "SJAF9Lle0HW", :text ":router", :by "root", :at 1500541010211}
-                       "j" {:type :leaf, :id "Byy95UlgRBW", :text "store", :by "root", :at 1500541010211}
+                       "T" {:type :leaf, :by "root", :at 1531641092131, :text ":overflow", :id "B1tW6u_Qm"}
+                       "j" {:type :leaf, :by "root", :at 1531641094027, :text ":auto", :id "HJHhW6ddmX"}
                       }
                      }
                     }
                    }
                   }
                  }
-                 "r" {
-                  :type :expr, :id "rkl99UlgCSZ", :by nil, :at 1500541010211
+                }
+               }
+               "T" {
+                :type :expr, :by "root", :at 1531641055156, :id "SJw1p_umX"
+                :data {
+                 "D" {:type :leaf, :by "root", :at 1531641056688, :text "div", :id "S1ewJau_X7"}
+                 "L" {
+                  :type :expr, :by "root", :at 1531641056911, :id "S1zYkaduXQ"
                   :data {
-                   "T" {:type :leaf, :id "rkbqq8xgAHb", :text "case", :by "root", :at 1500541010211}
+                   "T" {:type :leaf, :by "root", :at 1531641057259, :text "{}", :id "S1ZKJaO_QQ"}
                    "j" {
-                    :type :expr, :id "rkz5q8eeRH-", :by nil, :at 1500541010211
+                    :type :expr, :by "root", :at 1531641061822, :id "H1g0y6uu7X"
                     :data {
-                     "T" {:type :leaf, :id "HJX958ggAS-", :text ":name", :by "root", :at 1500541010211}
-                     "j" {:type :leaf, :id "HkE558leAH-", :text "router", :by "root", :at 1500541010211}
+                     "T" {:type :leaf, :by "root", :at 1531641062528, :text ":style", :id "SJCy6__m7"}
+                     "j" {
+                      :type :expr, :by "root", :at 1531641067336, :id "B1-7gpdu77"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1531641068156, :text "{}", :id "ryx7l6_dQQ"}
+                       "j" {
+                        :type :expr, :by "root", :at 1531641068350, :id "B1QVl6u_7X"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1531641070538, :text ":margin", :id "rJzVe6dOmQ"}
+                         "j" {:type :leaf, :by "root", :at 1531641073086, :text "\"0 auto", :id "HkeDlauuXQ"}
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "root", :at 1531641076366, :id "HJl2gp_uQX"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1531641079692, :text ":max-width", :id "HJl2gp_uQXleaf"}
+                         "j" {:type :leaf, :by "root", :at 1531641080825, :text "800", :id "rJ-lWp_dQX"}
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "T" {
+                  :type :expr, :id "rkXYc8ll0SW", :by nil, :at 1500541010211
+                  :data {
+                   "T" {:type :leaf, :id "HJVYcUxlRrZ", :text "if", :by "root", :at 1500541010211}
+                   "j" {
+                    :type :expr, :id "S1rK5UggABZ", :by nil, :at 1500541010211
+                    :data {
+                     "T" {:type :leaf, :id "rkUtqUxg0HZ", :text ":logged-in?", :by "root", :at 1500541010211}
+                     "j" {:type :leaf, :id "r1Dtq8lxArb", :text "store", :by "root", :at 1500541010211}
                     }
                    }
                    "r" {
-                    :type :expr, :id "rJH998xlAH-", :by nil, :at 1500541010211
+                    :type :expr, :id "B1dK5UggRBW", :by nil, :at 1500541010211
                     :data {
-                     "T" {:type :leaf, :id "H1LqqUexArZ", :text ":profile", :by "root", :at 1500541010211}
+                     "T" {:type :leaf, :id "H1FFc8lx0Hb", :text "let", :by "root", :at 1500541010211}
                      "j" {
-                      :type :expr, :id "B1v5cLxgASb", :by nil, :at 1500541010211
+                      :type :expr, :id "r1qFcIglRrb", :by nil, :at 1500541010211
                       :data {
-                       "T" {:type :leaf, :id "BJd95UxlRHZ", :text "comp-profile", :by "root", :at 1500541010211}
+                       "T" {
+                        :type :expr, :id "HyjK5UxgAr-", :by nil, :at 1500541010211
+                        :data {
+                         "T" {:type :leaf, :id "B12tqUxlASZ", :text "router", :by "root", :at 1500541010211}
+                         "j" {
+                          :type :expr, :id "HJ6Fc8xeRHW", :by nil, :at 1500541010211
+                          :data {
+                           "T" {:type :leaf, :id "SJAF9Lle0HW", :text ":router", :by "root", :at 1500541010211}
+                           "j" {:type :leaf, :id "Byy95UlgRBW", :text "store", :by "root", :at 1500541010211}
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                     "r" {
+                      :type :expr, :id "rkl99UlgCSZ", :by nil, :at 1500541010211
+                      :data {
+                       "T" {:type :leaf, :id "rkbqq8xgAHb", :text "case", :by "root", :at 1500541010211}
                        "j" {
-                        :type :expr, :id "ByF99IxlCBZ", :by nil, :at 1500541010211
+                        :type :expr, :id "rkz5q8eeRH-", :by nil, :at 1500541010211
                         :data {
-                         "T" {:type :leaf, :id "BJq558xxRBZ", :text ":user", :by "root", :at 1500541010211}
-                         "j" {:type :leaf, :id "HJo558lxAH-", :text "store", :by "root", :at 1500541010211}
+                         "T" {:type :leaf, :id "HJX958ggAS-", :text ":name", :by "root", :at 1500541010211}
+                         "j" {:type :leaf, :id "HkE558leAH-", :text "router", :by "root", :at 1500541010211}
                         }
                        }
-                      }
-                     }
-                    }
-                   }
-                   "t" {
-                    :type :expr, :by "root", :at 1520961937753, :id "Hk55YKrKf"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1520961939270, :text ":home", :id "Hk55YKrKfleaf"}
-                     "j" {
-                      :type :expr, :by "root", :at 1520961939578, :id "rJn5YYBFG"
-                      :data {
-                       "D" {:type :leaf, :by "root", :at 1520962131087, :text "cursor->", :id "BkcUcKrtz"}
-                       "L" {:type :leaf, :by "root", :at 1520962132217, :text ":home", :id "r1-s89KHKz"}
-                       "T" {:type :leaf, :by "root", :at 1520961941426, :text "comp-home", :id "BySi5YtSYG"}
-                       "j" {:type :leaf, :by "root", :at 1520962133363, :text "states", :id "rJT85trtz"}
                        "r" {
-                        :type :expr, :by "root", :at 1520962863000, :id "r1xvEpKBYM"
+                        :type :expr, :id "rJH998xlAH-", :by nil, :at 1500541010211
                         :data {
-                         "T" {:type :leaf, :by "root", :at 1520962869013, :text ":data", :id "B1wVTFrYf"}
-                         "j" {:type :leaf, :by "root", :at 1520962869986, :text "router", :id "SyE6NTtBKz"}
+                         "T" {:type :leaf, :id "H1LqqUexArZ", :text ":profile", :by "root", :at 1500541010211}
+                         "j" {
+                          :type :expr, :id "B1v5cLxgASb", :by nil, :at 1500541010211
+                          :data {
+                           "T" {:type :leaf, :id "BJd95UxlRHZ", :text "comp-profile", :by "root", :at 1500541010211}
+                           "j" {
+                            :type :expr, :id "ByF99IxlCBZ", :by nil, :at 1500541010211
+                            :data {
+                             "T" {:type :leaf, :id "BJq558xxRBZ", :text ":user", :by "root", :at 1500541010211}
+                             "j" {:type :leaf, :id "HJo558lxAH-", :text "store", :by "root", :at 1500541010211}
+                            }
+                           }
+                          }
+                         }
                         }
                        }
-                      }
-                     }
-                    }
-                   }
-                   "u" {
-                    :type :expr, :by "root", :at 1521044444854, :id "SySyhTLYG"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1521044447898, :text ":pending", :id "SySyhTLYGleaf"}
-                     "j" {
-                      :type :expr, :by "root", :at 1521044448218, :id "BJNdy3TIKG"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1521044452322, :text "cursor->", :id "rJQu1368Yf"}
-                       "j" {:type :leaf, :by "root", :at 1521044454852, :text ":pending", :id "SkTk2T8KG"}
-                       "r" {:type :leaf, :by "root", :at 1521044457285, :text "comp-pending", :id "r1X1x3p8FM"}
-                       "v" {:type :leaf, :by "root", :at 1521044458191, :text "states", :id "B1fl2TItf"}
-                       "x" {
-                        :type :expr, :by "root", :at 1521044460866, :id "B1eSx3pUYf"
+                       "t" {
+                        :type :expr, :by "root", :at 1520961937753, :id "Hk55YKrKf"
                         :data {
-                         "T" {:type :leaf, :by "root", :at 1521044462403, :text ":data", :id "SkHxnpUFz"}
-                         "j" {:type :leaf, :by "root", :at 1521044463214, :text "router", :id "BkPl2TItz"}
+                         "T" {:type :leaf, :by "root", :at 1520961939270, :text ":home", :id "Hk55YKrKfleaf"}
+                         "j" {
+                          :type :expr, :by "root", :at 1520961939578, :id "rJn5YYBFG"
+                          :data {
+                           "D" {:type :leaf, :by "root", :at 1520962131087, :text "cursor->", :id "BkcUcKrtz"}
+                           "L" {:type :leaf, :by "root", :at 1520962132217, :text ":home", :id "r1-s89KHKz"}
+                           "T" {:type :leaf, :by "root", :at 1520961941426, :text "comp-home", :id "BySi5YtSYG"}
+                           "j" {:type :leaf, :by "root", :at 1520962133363, :text "states", :id "rJT85trtz"}
+                           "r" {
+                            :type :expr, :by "root", :at 1520962863000, :id "r1xvEpKBYM"
+                            :data {
+                             "T" {:type :leaf, :by "root", :at 1520962869013, :text ":data", :id "B1wVTFrYf"}
+                             "j" {:type :leaf, :by "root", :at 1520962869986, :text "router", :id "SyE6NTtBKz"}
+                            }
+                           }
+                          }
+                         }
                         }
                        }
-                      }
-                     }
-                    }
-                   }
-                   "uT" {
-                    :type :expr, :by "root", :at 1521044444854, :id "B1f-eAUYf"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1521045499905, :text ":done", :id "SySyhTLYGleaf"}
-                     "j" {
-                      :type :expr, :by "root", :at 1521044448218, :id "BJNdy3TIKG"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1521044452322, :text "cursor->", :id "rJQu1368Yf"}
-                       "j" {:type :leaf, :by "root", :at 1521045501839, :text ":done", :id "SkTk2T8KG"}
-                       "r" {:type :leaf, :by "root", :at 1521045507199, :text "comp-done-tasks", :id "r1X1x3p8FM"}
-                       "v" {:type :leaf, :by "root", :at 1521044458191, :text "states", :id "B1fl2TItf"}
-                       "x" {
-                        :type :expr, :by "root", :at 1521044460866, :id "B1eSx3pUYf"
+                       "u" {
+                        :type :expr, :by "root", :at 1521044444854, :id "SySyhTLYG"
                         :data {
-                         "T" {:type :leaf, :by "root", :at 1521044462403, :text ":data", :id "SkHxnpUFz"}
-                         "j" {:type :leaf, :by "root", :at 1521044463214, :text "router", :id "BkPl2TItz"}
+                         "T" {:type :leaf, :by "root", :at 1521044447898, :text ":pending", :id "SySyhTLYGleaf"}
+                         "j" {
+                          :type :expr, :by "root", :at 1521044448218, :id "BJNdy3TIKG"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1521044452322, :text "cursor->", :id "rJQu1368Yf"}
+                           "j" {:type :leaf, :by "root", :at 1521044454852, :text ":pending", :id "SkTk2T8KG"}
+                           "r" {:type :leaf, :by "root", :at 1521044457285, :text "comp-pending", :id "r1X1x3p8FM"}
+                           "v" {:type :leaf, :by "root", :at 1521044458191, :text "states", :id "B1fl2TItf"}
+                           "x" {
+                            :type :expr, :by "root", :at 1521044460866, :id "B1eSx3pUYf"
+                            :data {
+                             "T" {:type :leaf, :by "root", :at 1521044462403, :text ":data", :id "SkHxnpUFz"}
+                             "j" {:type :leaf, :by "root", :at 1521044463214, :text "router", :id "BkPl2TItz"}
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                       "uT" {
+                        :type :expr, :by "root", :at 1521044444854, :id "B1f-eAUYf"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1521045499905, :text ":done", :id "SySyhTLYGleaf"}
+                         "j" {
+                          :type :expr, :by "root", :at 1521044448218, :id "BJNdy3TIKG"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1521044452322, :text "cursor->", :id "rJQu1368Yf"}
+                           "j" {:type :leaf, :by "root", :at 1521045501839, :text ":done", :id "SkTk2T8KG"}
+                           "r" {:type :leaf, :by "root", :at 1521045507199, :text "comp-done-tasks", :id "r1X1x3p8FM"}
+                           "v" {:type :leaf, :by "root", :at 1521044458191, :text "states", :id "B1fl2TItf"}
+                           "x" {
+                            :type :expr, :by "root", :at 1521044460866, :id "B1eSx3pUYf"
+                            :data {
+                             "T" {:type :leaf, :by "root", :at 1521044462403, :text ":data", :id "SkHxnpUFz"}
+                             "j" {:type :leaf, :by "root", :at 1521044463214, :text "router", :id "BkPl2TItz"}
+                            }
+                           }
+                          }
+                         }
+                        }
+                       }
+                       "v" {
+                        :type :expr, :id "BJ35cUexRBb", :by nil, :at 1500541010211
+                        :data {
+                         "T" {:type :leaf, :id "rypccUgxCBb", :text "<>", :by "root", :at 1520875364263}
+                         "j" {:type :leaf, :by "root", :at 1520875366839, :text "router", :id "S16PwEEKM"}
+                         "r" {:type :leaf, :by "root", :at 1520875367609, :text "nil", :id "H1bydPNEtz"}
                         }
                        }
                       }
@@ -1116,22 +1193,14 @@
                     }
                    }
                    "v" {
-                    :type :expr, :id "BJ35cUexRBb", :by nil, :at 1500541010211
+                    :type :expr, :id "BkciqUxgRrZ", :by nil, :at 1500541010211
                     :data {
-                     "T" {:type :leaf, :id "rypccUgxCBb", :text "<>", :by "root", :at 1520875364263}
-                     "j" {:type :leaf, :by "root", :at 1520875366839, :text "router", :id "S16PwEEKM"}
-                     "r" {:type :leaf, :by "root", :at 1520875367609, :text "nil", :id "H1bydPNEtz"}
+                     "T" {:type :leaf, :id "BysicIxgAHW", :text "comp-login", :by "root", :at 1500541010211}
+                     "j" {:type :leaf, :id "rkhocIleRrb", :text "states", :by "root", :at 1500541010211}
                     }
                    }
                   }
                  }
-                }
-               }
-               "v" {
-                :type :expr, :id "BkciqUxgRrZ", :by nil, :at 1500541010211
-                :data {
-                 "T" {:type :leaf, :id "BysicIxgAHW", :text "comp-login", :by "root", :at 1500541010211}
-                 "j" {:type :leaf, :id "rkhocIleRrb", :text "states", :by "root", :at 1500541010211}
                 }
                }
               }
@@ -6590,68 +6659,46 @@
         }
        }
        "v" {
-        :type :expr, :id "rkW_zqUxlCrZ", :by nil, :at 1500541010211
+        :type :expr, :by "root", :at 1531641154666, :id "HJsraOdQ7"
         :data {
-         "T" {:type :leaf, :id "HJM_fc8elAHW", :text "div", :by "root", :at 1500541010211}
-         "j" {
-          :type :expr, :id "H1QdzqLge0SW", :by nil, :at 1500541010211
+         "D" {:type :leaf, :by "root", :at 1531641155584, :text "div", :id "ryejrpdu7X"}
+         "L" {
+          :type :expr, :by "root", :at 1531641155816, :id "Hy-hSTuO7Q"
           :data {
-           "T" {:type :leaf, :id "BJNOG5LleABZ", :text "{}", :by "root", :at 1500541010211}
+           "T" {:type :leaf, :by "root", :at 1531641156563, :text "{}", :id "Hyx2BT__Q7"}
            "j" {
-            :type :expr, :id "SyBufq8elAHZ", :by nil, :at 1500541010211
+            :type :expr, :by "root", :at 1531641163113, :id "r1ZX8pdOmX"
             :data {
-             "T" {:type :leaf, :id "rkUOfqIxxRS-", :text ":style", :by "root", :at 1500541010211}
+             "T" {:type :leaf, :by "root", :at 1531641165098, :text ":style", :id "r1gX8T_OmQ"}
              "j" {
-              :type :expr, :id "r1vdGcUglRr-", :by nil, :at 1500541010211
+              :type :expr, :id "ryWP8TddQ7", :by nil, :at 1500541010211
               :data {
-               "T" {:type :leaf, :id "H1u_z9Ixe0HZ", :text "merge", :by "root", :at 1500541010211}
-               "j" {:type :leaf, :id "H1YdfcUxxCB-", :text "ui/column-parted", :by "root", :at 1520874873176}
-               "r" {
-                :type :expr, :id "S15_rVVFG", :by nil, :at 1500541010211
+               "T" {:type :leaf, :id "Byb2zcIlx0SW", :text "{}", :by "root", :at 1500541010211}
+               "yv" {
+                :type :expr, :by "root", :at 1531641116610, :id "BySX6d_X7"
                 :data {
-                 "T" {:type :leaf, :id "Byb2zcIlx0SW", :text "{}", :by "root", :at 1500541010211}
-                 "y" {
-                  :type :expr, :id "SJR2MqIlx0S-", :by nil, :at 1500541010211
+                 "T" {:type :leaf, :by "root", :at 1531641120862, :text ":flex-shrink", :id "BySX6d_X7leaf"}
+                 "j" {:type :leaf, :by "root", :at 1531641121606, :text "0", :id "SyzFX6ddmm"}
+                }
+               }
+               "yx" {
+                :type :expr, :by "root", :at 1531641127431, :id "rJe1N6dOmm"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1531641129583, :text ":border-bottom", :id "rJe1N6dOmmleaf"}
+                 "j" {
+                  :type :expr, :by "root", :at 1531641129903, :id "B1GzN6uOmX"
                   :data {
-                   "T" {:type :leaf, :id "SkkpfcUxeCHb", :text ":font-size", :by "root", :at 1500541010211}
-                   "j" {:type :leaf, :id "SJeazq8llABZ", :text "24", :by "root", :at 1520875030792}
-                  }
-                 }
-                 "yT" {
-                  :type :expr, :by "root", :at 1519314625999, :id "Bkl9pLP2Pf"
-                  :data {
-                   "T" {:type :leaf, :by "root", :at 1520874883450, :text ":border-right", :id "Bkl9pLP2Pfleaf"}
-                   "j" {
-                    :type :expr, :by "root", :at 1519314630743, :id "rkgy08vnwf"
+                   "T" {:type :leaf, :by "root", :at 1531641130375, :text "str", :id "ryZMEaOO7Q"}
+                   "j" {:type :leaf, :by "root", :at 1531641132857, :text "\"1px solid ", :id "H1QNTd_mX"}
+                   "r" {
+                    :type :expr, :by "root", :at 1531641133859, :id "S1xLNa_O7Q"
                     :data {
-                     "T" {:type :leaf, :by "root", :at 1519314632214, :text "str", :id "SJk0UDhDG"}
-                     "j" {:type :leaf, :by "root", :at 1519314635000, :text "|1px solid ", :id "rJEl08P3wf"}
-                     "r" {
-                      :type :expr, :by "root", :at 1519314635976, :id "SyxNRUw2Pz"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1519314636519, :text "hsl", :id "BJVRIPnvM"}
-                       "j" {:type :leaf, :by "root", :at 1519314637558, :text "0", :id "SklrAUwhvz"}
-                       "r" {:type :leaf, :by "root", :at 1519314637788, :text "0", :id "HJeIRIwnPG"}
-                       "v" {:type :leaf, :by "root", :at 1519314638678, :text "0", :id "ByMUC8vnPM"}
-                       "x" {:type :leaf, :by "root", :at 1519314643853, :text "0.1", :id "HkgD0IwhPM"}
-                      }
-                     }
+                     "T" {:type :leaf, :by "root", :at 1531641134327, :text "hsl", :id "ryL4audX7"}
+                     "j" {:type :leaf, :by "root", :at 1531641134632, :text "0", :id "HyvN6O_7m"}
+                     "r" {:type :leaf, :by "root", :at 1531641134993, :text "0", :id "r1Zv4T_umQ"}
+                     "v" {:type :leaf, :by "root", :at 1531641136507, :text "90", :id "B17v46_OXm"}
                     }
                    }
-                  }
-                 }
-                 "yj" {
-                  :type :expr, :by "root", :at 1519314651278, :id "B1-mkPw2DG"
-                  :data {
-                   "T" {:type :leaf, :by "root", :at 1519314653842, :text ":font-family", :id "B1-mkPw2DGleaf"}
-                   "j" {:type :leaf, :by "root", :at 1519314661374, :text "ui/font-fancy", :id "Bkg81wD2wz"}
-                  }
-                 }
-                 "yr" {
-                  :type :expr, :by "root", :at 1521737903773, :id "SkuheP-qf"
-                  :data {
-                   "T" {:type :leaf, :by "root", :at 1521737905054, :text ":padding", :id "SkuheP-qfleaf"}
-                   "j" {:type :leaf, :by "root", :at 1521738032535, :text "|8 8px", :id "HkEt2gvWqG"}
                   }
                  }
                 }
@@ -6662,509 +6709,127 @@
            }
           }
          }
-         "r" {
-          :type :expr, :by "root", :at 1520875047898, :id "rJgxVUVVtf"
+         "T" {
+          :type :expr, :id "rkW_zqUxlCrZ", :by nil, :at 1500541010211
           :data {
-           "D" {:type :leaf, :by "root", :at 1520875048669, :text "div", :id "SJ-lELV4Fz"}
-           "L" {
-            :type :expr, :by "root", :at 1520875048910, :id "H1MWEIV4Yf"
-            :data {
-             "T" {:type :leaf, :by "root", :at 1520875050291, :text "{}", :id "ryZZVUV4YG"}
-             "j" {
-              :type :expr, :by "root", :at 1520875051016, :id "SJMX484EFM"
-              :data {
-               "T" {:type :leaf, :by "root", :at 1521737727296, :text ":style", :id "S1lXNLVVtG"}
-               "j" {
-                :type :expr, :by "root", :at 1521737727653, :id "S1O-lwW9G"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1521737727974, :text "{}", :id "H1zwbxwW5M"}
-                }
-               }
-              }
-             }
-            }
-           }
-           "T" {
-            :type :expr, :id "Bkj_M9LlxCHb", :by nil, :at 1500541010211
-            :data {
-             "T" {:type :leaf, :id "Hk3dfcUex0rW", :text "div", :by "root", :at 1500541010211}
-             "j" {
-              :type :expr, :id "BJT_z5UgeRB-", :by nil, :at 1500541010211
-              :data {
-               "T" {:type :leaf, :id "rkCufcIex0rb", :text "{}", :by "root", :at 1500541010211}
-               "j" {
-                :type :expr, :id "BkxztoJgmz", :by nil, :at 1500541010211
-                :data {
-                 "T" {:type :leaf, :id "SJVtzcUllCSW", :text ":on-click", :by "root", :at 1514302328636}
-                 "j" {
-                  :type :expr, :by "root", :at 1520875297716, :id "H1ecmvEEYz"
-                  :data {
-                   "T" {:type :leaf, :id "BkSFGqIelRSb", :text "fn", :by "root", :at 1520875299130}
-                   "j" {
-                    :type :expr, :by "root", :at 1520875299945, :id "Byh7wVNFz"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1520875301244, :text "e", :id "HJeoQDV4tf"}
-                     "j" {:type :leaf, :by "root", :at 1520875303034, :text "d!", :id "Hke6QvNNKf"}
-                     "r" {:type :leaf, :by "root", :at 1520875303747, :text "m!", :id "SyZkNwENKG"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :id "S1l-NDVEtf", :by nil, :at 1500541010211
-                    :data {
-                     "T" {:type :leaf, :id "B1iaGcIexAHZ", :text "d!", :by "root", :at 1520875308253}
-                     "j" {:type :leaf, :id "H126zqIglRB-", :text ":router/change", :by "root", :at 1500541010211}
-                     "r" {
-                      :type :expr, :id "Sy6pz58llCrW", :by nil, :at 1500541010211
-                      :data {
-                       "T" {:type :leaf, :id "SJRaG9IxlAB-", :text "{}", :by "root", :at 1500541010211}
-                       "j" {
-                        :type :expr, :id "BJk0zq8xxCr-", :by nil, :at 1500541010211
-                        :data {
-                         "T" {:type :leaf, :id "BJg0MqUxe0r-", :text ":name", :by "root", :at 1500541010211}
-                         "j" {:type :leaf, :id "SyWCG5IlgAS-", :text ":home", :by "root", :at 1500541010211}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-               "r" {
-                :type :expr, :by "root", :at 1520875268221, :id "SJhbw4Ntf"
-                :data {
-                 "D" {:type :leaf, :by "root", :at 1520875271640, :text ":style", :id "r10ZwNEKz"}
-                 "T" {
-                  :type :expr, :by "root", :at 1520961731005, :id "ryxWtKrYz"
-                  :data {
-                   "D" {:type :leaf, :by "root", :at 1520961732826, :text "merge", :id "r1giTdtHYf"}
-                   "L" {:type :leaf, :by "root", :at 1521737550897, :text "ui/row", :id "HkE81PW5f"}
-                   "T" {:type :leaf, :by "root", :at 1520875259977, :text "style-entry", :id "H1QgVZPNVtf"}
-                   "j" {
-                    :type :expr, :by "root", :at 1520961733434, :id "rJNaTdKSFM"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1520961734074, :text "if", :id "rympTdYBYz"}
-                     "j" {
-                      :type :expr, :by "root", :at 1520961736037, :id "HyexRdYBFf"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1520961735598, :text "=", :id "rJyC_YHKG"}
-                       "j" {:type :leaf, :by "root", :at 1520961788039, :text ":home", :id "Bk-RdFrKG"}
-                       "r" {
-                        :type :expr, :by "root", :at 1520961762439, :id "ByS9kKKSYf"
-                        :data {
-                         "T" {:type :leaf, :by "root", :at 1520961763035, :text ":name", :id "SkE5yttrKM"}
-                         "j" {:type :leaf, :by "root", :at 1520961763774, :text "router", :id "SkVoyKtrtf"}
-                        }
-                       }
-                      }
-                     }
-                     "r" {
-                      :type :expr, :by "root", :at 1520961766080, :id "S1bAkKYBYz"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1520961765338, :text "{}", :id "S1xakKFBKf"}
-                       "j" {
-                        :type :expr, :by "root", :at 1520961767628, :id "B1ggYFBYf"
-                        :data {
-                         "T" {:type :leaf, :by "root", :at 1520961768841, :text ":color", :id "BkM01FFrKG"}
-                         "j" {:type :leaf, :by "root", :at 1520961771434, :text ":black", :id "SJM-eKYrKG"}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-             "r" {
-              :type :expr, :by "root", :at 1521737936096, :id "Skd0xv-cz"
-              :data {
-               "D" {:type :leaf, :by "root", :at 1521737937617, :text "div", :id "ByKAew-cG"}
-               "L" {
-                :type :expr, :by "root", :at 1521737937859, :id "HyzqClDbqf"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1521737938184, :text "{}", :id "rk-c0xPZ9G"}
-                 "j" {
-                  :type :expr, :by "root", :at 1521737938459, :id "SkI9AgPZqz"
-                  :data {
-                   "T" {:type :leaf, :by "root", :at 1521737943151, :text ":style", :id "B1HcRgDWqG"}
-                   "j" {:type :leaf, :by "root", :at 1521737945741, :text "style-icon", :id "SJxkZwbqG"}
-                  }
-                 }
-                }
-               }
-               "f" {
-                :type :expr, :by "root", :at 1520874796553, :id "BJwWWDWqM"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1520874797079, :text "comp-icon", :id "HJBNBE4tGleaf"}
-                 "j" {:type :leaf, :by "root", :at 1520874800662, :text ":home", :id "HkLNSNEKM"}
-                }
-               }
-              }
-             }
-             "v" {
-              :type :expr, :by "root", :at 1521737552520, :id "rygQWZPb9z"
-              :data {
-               "T" {:type :leaf, :by "root", :at 1521737552828, :text "<>", :id "ByFL1vZ9Mleaf"}
-               "j" {
-                :type :expr, :by "root", :at 1521737554545, :id "H1jLJvW9M"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1521737557214, :text ":working", :id "Sy7KU1P-cf"}
-                 "j" {:type :leaf, :by "root", :at 1521737558836, :text "numbers", :id "BkC81w-qz"}
-                }
-               }
-               "r" {:type :leaf, :by "root", :at 1521737853644, :text "style-count", :id "rylrFewWqG"}
-              }
-             }
-            }
-           }
+           "T" {:type :leaf, :id "HJM_fc8elAHW", :text "div", :by "root", :at 1500541010211}
            "j" {
-            :type :expr, :id "SyMsUENFG", :by nil, :at 1500541010211
+            :type :expr, :id "H1QdzqLge0SW", :by nil, :at 1500541010211
             :data {
-             "T" {:type :leaf, :id "Hk3dfcUex0rW", :text "div", :by "root", :at 1500541010211}
+             "T" {:type :leaf, :id "BJNOG5LleABZ", :text "{}", :by "root", :at 1500541010211}
              "j" {
-              :type :expr, :id "BJT_z5UgeRB-", :by nil, :at 1500541010211
+              :type :expr, :id "SyBufq8elAHZ", :by nil, :at 1500541010211
               :data {
-               "T" {:type :leaf, :id "rkCufcIex0rb", :text "{}", :by "root", :at 1500541010211}
+               "T" {:type :leaf, :id "rkUOfqIxxRS-", :text ":style", :by "root", :at 1500541010211}
                "j" {
-                :type :expr, :id "BkxztoJgmz", :by nil, :at 1500541010211
+                :type :expr, :id "r1vdGcUglRr-", :by nil, :at 1500541010211
                 :data {
-                 "T" {:type :leaf, :id "SJVtzcUllCSW", :text ":on-click", :by "root", :at 1514302328636}
-                 "j" {
-                  :type :expr, :by "root", :at 1520875297716, :id "BJePNw4EKG"
+                 "T" {:type :leaf, :id "H1u_z9Ixe0HZ", :text "merge", :by "root", :at 1500541010211}
+                 "j" {:type :leaf, :id "H1YdfcUxxCB-", :text "ui/row-parted", :by "root", :at 1531640761075}
+                 "r" {
+                  :type :expr, :id "S15_rVVFG", :by nil, :at 1500541010211
                   :data {
-                   "T" {:type :leaf, :id "BkSFGqIelRSb", :text "fn", :by "root", :at 1520875299130}
-                   "j" {
-                    :type :expr, :by "root", :at 1520875299945, :id "Byh7wVNFz"
+                   "T" {:type :leaf, :id "Byb2zcIlx0SW", :text "{}", :by "root", :at 1500541010211}
+                   "y" {
+                    :type :expr, :id "SJR2MqIlx0S-", :by nil, :at 1500541010211
                     :data {
-                     "T" {:type :leaf, :by "root", :at 1520875301244, :text "e", :id "HJeoQDV4tf"}
-                     "j" {:type :leaf, :by "root", :at 1520875303034, :text "d!", :id "Hke6QvNNKf"}
-                     "r" {:type :leaf, :by "root", :at 1520875303747, :text "m!", :id "SyZkNwENKG"}
+                     "T" {:type :leaf, :id "SkkpfcUxeCHb", :text ":font-size", :by "root", :at 1500541010211}
+                     "j" {:type :leaf, :id "SJeazq8llABZ", :text "24", :by "root", :at 1520875030792}
                     }
                    }
-                   "r" {
-                    :type :expr, :id "S1l-NDVEtf", :by nil, :at 1500541010211
+                   "yj" {
+                    :type :expr, :by "root", :at 1519314651278, :id "B1-mkPw2DG"
                     :data {
-                     "T" {:type :leaf, :id "B1iaGcIexAHZ", :text "d!", :by "root", :at 1520875308253}
-                     "j" {:type :leaf, :id "H126zqIglRB-", :text ":router/change", :by "root", :at 1500541010211}
-                     "r" {
-                      :type :expr, :id "Sy6pz58llCrW", :by nil, :at 1500541010211
-                      :data {
-                       "T" {:type :leaf, :id "SJRaG9IxlAB-", :text "{}", :by "root", :at 1500541010211}
-                       "j" {
-                        :type :expr, :id "BJk0zq8xxCr-", :by nil, :at 1500541010211
-                        :data {
-                         "T" {:type :leaf, :id "BJg0MqUxe0r-", :text ":name", :by "root", :at 1500541010211}
-                         "j" {:type :leaf, :id "SyWCG5IlgAS-", :text ":pending", :by "root", :at 1520962777871}
-                        }
-                       }
-                      }
-                     }
+                     "T" {:type :leaf, :by "root", :at 1519314653842, :text ":font-family", :id "B1-mkPw2DGleaf"}
+                     "j" {:type :leaf, :by "root", :at 1519314661374, :text "ui/font-fancy", :id "Bkg81wD2wz"}
                     }
                    }
-                  }
-                 }
-                }
-               }
-               "r" {
-                :type :expr, :by "root", :at 1520875268221, :id "S1gffDNEKz"
-                :data {
-                 "D" {:type :leaf, :by "root", :at 1520875271640, :text ":style", :id "r10ZwNEKz"}
-                 "T" {
-                  :type :expr, :by "root", :at 1520961731005, :id "SkjTOFSKG"
-                  :data {
-                   "D" {:type :leaf, :by "root", :at 1520961732826, :text "merge", :id "r1giTdtHYf"}
-                   "L" {:type :leaf, :by "root", :at 1521737624674, :text "ui/row", :id "r1lR9kw-5G"}
-                   "T" {:type :leaf, :by "root", :at 1520875259977, :text "style-entry", :id "H1QgVZPNVtf"}
-                   "j" {
-                    :type :expr, :by "root", :at 1520961733434, :id "rJNaTdKSFM"
+                   "yr" {
+                    :type :expr, :by "root", :at 1521737903773, :id "SkuheP-qf"
                     :data {
-                     "T" {:type :leaf, :by "root", :at 1520961734074, :text "if", :id "rympTdYBYz"}
-                     "j" {
-                      :type :expr, :by "root", :at 1520961736037, :id "HyexRdYBFf"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1520961735598, :text "=", :id "rJyC_YHKG"}
-                       "j" {:type :leaf, :by "root", :at 1520962782647, :text ":pending", :id "Bk-RdFrKG"}
-                       "r" {
-                        :type :expr, :by "root", :at 1520961762439, :id "ByS9kKKSYf"
-                        :data {
-                         "T" {:type :leaf, :by "root", :at 1520961763035, :text ":name", :id "SkE5yttrKM"}
-                         "j" {:type :leaf, :by "root", :at 1520961763774, :text "router", :id "SkVoyKtrtf"}
-                        }
-                       }
-                      }
-                     }
-                     "r" {
-                      :type :expr, :by "root", :at 1520961766080, :id "S1bAkKYBYz"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1520961765338, :text "{}", :id "S1xakKFBKf"}
-                       "j" {
-                        :type :expr, :by "root", :at 1520961767628, :id "B1ggYFBYf"
-                        :data {
-                         "T" {:type :leaf, :by "root", :at 1520961768841, :text ":color", :id "BkM01FFrKG"}
-                         "j" {:type :leaf, :by "root", :at 1520961771434, :text ":black", :id "SJM-eKYrKG"}
-                        }
-                       }
-                      }
-                     }
+                     "T" {:type :leaf, :by "root", :at 1521737905054, :text ":padding", :id "SkuheP-qfleaf"}
+                     "j" {:type :leaf, :by "root", :at 1521738032535, :text "|8 8px", :id "HkEt2gvWqG"}
+                    }
+                   }
+                   "yv" {
+                    :type :expr, :by "root", :at 1531641178818, :id "rkmw6OOm7"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1531641183394, :text ":max-width", :id "rkmw6OOm7leaf"}
+                     "j" {:type :leaf, :by "root", :at 1531641184135, :text "800", :id "SkOPpuuX7"}
+                    }
+                   }
+                   "yx" {
+                    :type :expr, :by "root", :at 1531641186845, :id "rJliPTduXX"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1531641189249, :text ":margin", :id "rJliPTduXXleaf"}
+                     "j" {:type :leaf, :by "root", :at 1531641190352, :text ":auto", :id "BymaDTdOXQ"}
                     }
                    }
                   }
                  }
                 }
                }
-              }
-             }
-             "n" {
-              :type :expr, :by "root", :at 1521737936096, :id "H1bH1bDWqM"
-              :data {
-               "D" {:type :leaf, :by "root", :at 1521737937617, :text "div", :id "ByKAew-cG"}
-               "L" {
-                :type :expr, :by "root", :at 1521737937859, :id "HyzqClDbqf"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1521737938184, :text "{}", :id "rk-c0xPZ9G"}
-                 "j" {
-                  :type :expr, :by "root", :at 1521737938459, :id "SkI9AgPZqz"
-                  :data {
-                   "T" {:type :leaf, :by "root", :at 1521737943151, :text ":style", :id "B1HcRgDWqG"}
-                   "j" {:type :leaf, :by "root", :at 1521737945741, :text "style-icon", :id "SJxkZwbqG"}
-                  }
-                 }
-                }
-               }
-               "T" {
-                :type :expr, :by "root", :at 1520874796553, :id "Byzpgbv-qz"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1520874797079, :text "comp-icon", :id "HJBNBE4tGleaf"}
-                 "j" {:type :leaf, :by "root", :at 1520875172462, :text ":ios-time-outline", :id "HkLNSNEKM"}
-                }
-               }
-              }
-             }
-             "v" {
-              :type :expr, :by "root", :at 1521737629299, :id "BJeSskwZcz"
-              :data {
-               "T" {:type :leaf, :by "root", :at 1521737629893, :text "<>", :id "BJeSskwZczleaf"}
-               "j" {
-                :type :expr, :by "root", :at 1521737630263, :id "BJGIsyv-cf"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1521737632367, :text ":pending", :id "SJ-LokwWqM"}
-                 "j" {:type :leaf, :by "root", :at 1521737635823, :text "numbers", :id "rJ9oJvWqf"}
-                }
-               }
-               "r" {:type :leaf, :by "root", :at 1521737858250, :text "style-count", :id "HJeqYlDW9G"}
               }
              }
             }
            }
            "r" {
-            :type :expr, :id "ByMeP4VYM", :by nil, :at 1500541010211
+            :type :expr, :by "root", :at 1520875047898, :id "rJgxVUVVtf"
             :data {
-             "T" {:type :leaf, :id "Hk3dfcUex0rW", :text "div", :by "root", :at 1500541010211}
-             "j" {
-              :type :expr, :id "BJT_z5UgeRB-", :by nil, :at 1500541010211
+             "D" {:type :leaf, :by "root", :at 1520875048669, :text "div", :id "SJ-lELV4Fz"}
+             "L" {
+              :type :expr, :by "root", :at 1520875048910, :id "H1MWEIV4Yf"
               :data {
-               "T" {:type :leaf, :id "rkCufcIex0rb", :text "{}", :by "root", :at 1500541010211}
+               "T" {:type :leaf, :by "root", :at 1520875050291, :text "{}", :id "ryZZVUV4YG"}
                "j" {
-                :type :expr, :id "BkxztoJgmz", :by nil, :at 1500541010211
+                :type :expr, :by "root", :at 1520875051016, :id "SJMX484EFM"
                 :data {
-                 "T" {:type :leaf, :id "SJVtzcUllCSW", :text ":on-click", :by "root", :at 1514302328636}
-                 "j" {
-                  :type :expr, :by "root", :at 1520875297716, :id "H1xdVwEVKM"
-                  :data {
-                   "T" {:type :leaf, :id "BkSFGqIelRSb", :text "fn", :by "root", :at 1520875299130}
-                   "j" {
-                    :type :expr, :by "root", :at 1520875299945, :id "Byh7wVNFz"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1520875301244, :text "e", :id "HJeoQDV4tf"}
-                     "j" {:type :leaf, :by "root", :at 1520875303034, :text "d!", :id "Hke6QvNNKf"}
-                     "r" {:type :leaf, :by "root", :at 1520875303747, :text "m!", :id "SyZkNwENKG"}
-                    }
-                   }
-                   "r" {
-                    :type :expr, :id "S1l-NDVEtf", :by nil, :at 1500541010211
-                    :data {
-                     "T" {:type :leaf, :id "B1iaGcIexAHZ", :text "d!", :by "root", :at 1520875308253}
-                     "j" {:type :leaf, :id "H126zqIglRB-", :text ":router/change", :by "root", :at 1500541010211}
-                     "r" {
-                      :type :expr, :id "Sy6pz58llCrW", :by nil, :at 1500541010211
-                      :data {
-                       "T" {:type :leaf, :id "SJRaG9IxlAB-", :text "{}", :by "root", :at 1500541010211}
-                       "j" {
-                        :type :expr, :id "BJk0zq8xxCr-", :by nil, :at 1500541010211
-                        :data {
-                         "T" {:type :leaf, :id "BJg0MqUxe0r-", :text ":name", :by "root", :at 1500541010211}
-                         "j" {:type :leaf, :id "SyWCG5IlgAS-", :text ":done", :by "root", :at 1520875322006}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
+                 "T" {:type :leaf, :by "root", :at 1521737727296, :text ":style", :id "S1lXNLVVtG"}
+                 "j" {:type :leaf, :by "root", :at 1531640846609, :text "ui/row", :id "SkZHfnu_Qm"}
                 }
                }
-               "r" {
-                :type :expr, :by "root", :at 1520875268221, :id "SylXfvNEtG"
+              }
+             }
+             "T" {
+              :type :expr, :id "Bkj_M9LlxCHb", :by nil, :at 1500541010211
+              :data {
+               "T" {:type :leaf, :id "Hk3dfcUex0rW", :text "div", :by "root", :at 1500541010211}
+               "j" {
+                :type :expr, :id "BJT_z5UgeRB-", :by nil, :at 1500541010211
                 :data {
-                 "D" {:type :leaf, :by "root", :at 1520875271640, :text ":style", :id "r10ZwNEKz"}
-                 "T" {
-                  :type :expr, :by "root", :at 1520961731005, :id "BycxKKSYG"
+                 "T" {:type :leaf, :id "rkCufcIex0rb", :text "{}", :by "root", :at 1500541010211}
+                 "j" {
+                  :type :expr, :id "BkxztoJgmz", :by nil, :at 1500541010211
                   :data {
-                   "D" {:type :leaf, :by "root", :at 1520961732826, :text "merge", :id "r1giTdtHYf"}
-                   "L" {:type :leaf, :by "root", :at 1521737642779, :text "ui/row", :id "B1fnywW5M"}
-                   "T" {:type :leaf, :by "root", :at 1520875259977, :text "style-entry", :id "H1QgVZPNVtf"}
+                   "T" {:type :leaf, :id "SJVtzcUllCSW", :text ":on-click", :by "root", :at 1514302328636}
                    "j" {
-                    :type :expr, :by "root", :at 1520961733434, :id "rJNaTdKSFM"
+                    :type :expr, :by "root", :at 1520875297716, :id "H1ecmvEEYz"
                     :data {
-                     "T" {:type :leaf, :by "root", :at 1520961734074, :text "if", :id "rympTdYBYz"}
+                     "T" {:type :leaf, :id "BkSFGqIelRSb", :text "fn", :by "root", :at 1520875299130}
                      "j" {
-                      :type :expr, :by "root", :at 1520961736037, :id "HyexRdYBFf"
+                      :type :expr, :by "root", :at 1520875299945, :id "Byh7wVNFz"
                       :data {
-                       "T" {:type :leaf, :by "root", :at 1520961735598, :text "=", :id "rJyC_YHKG"}
-                       "j" {:type :leaf, :by "root", :at 1520961781293, :text ":done", :id "Bk-RdFrKG"}
-                       "r" {
-                        :type :expr, :by "root", :at 1520961762439, :id "ByS9kKKSYf"
-                        :data {
-                         "T" {:type :leaf, :by "root", :at 1520961763035, :text ":name", :id "SkE5yttrKM"}
-                         "j" {:type :leaf, :by "root", :at 1520961763774, :text "router", :id "SkVoyKtrtf"}
-                        }
-                       }
+                       "T" {:type :leaf, :by "root", :at 1520875301244, :text "e", :id "HJeoQDV4tf"}
+                       "j" {:type :leaf, :by "root", :at 1520875303034, :text "d!", :id "Hke6QvNNKf"}
+                       "r" {:type :leaf, :by "root", :at 1520875303747, :text "m!", :id "SyZkNwENKG"}
                       }
                      }
                      "r" {
-                      :type :expr, :by "root", :at 1520961766080, :id "S1bAkKYBYz"
+                      :type :expr, :id "S1l-NDVEtf", :by nil, :at 1500541010211
                       :data {
-                       "T" {:type :leaf, :by "root", :at 1520961765338, :text "{}", :id "S1xakKFBKf"}
-                       "j" {
-                        :type :expr, :by "root", :at 1520961767628, :id "B1ggYFBYf"
-                        :data {
-                         "T" {:type :leaf, :by "root", :at 1520961768841, :text ":color", :id "BkM01FFrKG"}
-                         "j" {:type :leaf, :by "root", :at 1520961771434, :text ":black", :id "SJM-eKYrKG"}
-                        }
-                       }
-                      }
-                     }
-                    }
-                   }
-                  }
-                 }
-                }
-               }
-              }
-             }
-             "n" {
-              :type :expr, :by "root", :at 1521737936096, :id "B1b2y-Pb5G"
-              :data {
-               "D" {:type :leaf, :by "root", :at 1521737937617, :text "div", :id "ByKAew-cG"}
-               "L" {
-                :type :expr, :by "root", :at 1521737937859, :id "HyzqClDbqf"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1521737938184, :text "{}", :id "rk-c0xPZ9G"}
-                 "j" {
-                  :type :expr, :by "root", :at 1521737938459, :id "SkI9AgPZqz"
-                  :data {
-                   "T" {:type :leaf, :by "root", :at 1521737943151, :text ":style", :id "B1HcRgDWqG"}
-                   "j" {:type :leaf, :by "root", :at 1521737945741, :text "style-icon", :id "SJxkZwbqG"}
-                  }
-                 }
-                }
-               }
-               "T" {
-                :type :expr, :by "root", :at 1520874796553, :id "H1ejgbDZ9M"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1520874797079, :text "comp-icon", :id "HJBNBE4tGleaf"}
-                 "j" {:type :leaf, :by "root", :at 1520875245380, :text ":social-buffer", :id "HkLNSNEKM"}
-                }
-               }
-              }
-             }
-             "v" {
-              :type :expr, :by "root", :at 1521737644212, :id "SkgVnkP-9f"
-              :data {
-               "T" {:type :leaf, :by "root", :at 1521737644918, :text "<>", :id "SkgVnkP-9fleaf"}
-               "j" {
-                :type :expr, :by "root", :at 1521737646014, :id "SygIhJv-qG"
-                :data {
-                 "T" {:type :leaf, :by "root", :at 1521737646552, :text ":done", :id "H1Zr3yDZcM"}
-                 "j" {:type :leaf, :by "root", :at 1521737647861, :text "numbers", :id "Syxw3ywZ9z"}
-                }
-               }
-               "r" {:type :leaf, :by "root", :at 1521737862971, :text "style-count", :id "rJ1cgv-cf"}
-              }
-             }
-            }
-           }
-          }
-         }
-         "v" {
-          :type :expr, :by "root", :at 1521220013466, :id "SyHnKdYFz"
-          :data {
-           "D" {:type :leaf, :by "root", :at 1521220014248, :text "div", :id "rk82Y_YKM"}
-           "L" {
-            :type :expr, :by "root", :at 1521220014493, :id "HkVIhK_FKM"
-            :data {
-             "T" {:type :leaf, :by "root", :at 1521220014882, :text "{}", :id "rJXIhKOYKG"}
-             "j" {
-              :type :expr, :by "root", :at 1521220018728, :id "SJ-i3Y_KFM"
-              :data {
-               "T" {:type :leaf, :by "root", :at 1521220019636, :text ":style", :id "Hyo3tuYFz"}
-               "j" {:type :leaf, :by "root", :at 1521220022388, :text "ui/column", :id "Bkx33F_KYM"}
-              }
-             }
-            }
-           }
-           "T" {
-            :type :expr, :id "H10FM9IeeRBb", :by nil, :at 1500541010211
-            :data {
-             "T" {:type :leaf, :id "ByyqzcUglRHZ", :text "div", :by "root", :at 1500541010211}
-             "j" {
-              :type :expr, :id "rkl5GcLglABW", :by nil, :at 1500541010211
-              :data {
-               "T" {:type :leaf, :id "HybqMqUge0SW", :text "{}", :by "root", :at 1500541010211}
-               "j" {
-                :type :expr, :by "root", :at 1520875268221, :id "HkeLzvEEFM"
-                :data {
-                 "D" {:type :leaf, :by "root", :at 1520875271640, :text ":style", :id "r10ZwNEKz"}
-                 "T" {
-                  :type :expr, :by "root", :at 1520961731005, :id "Sk5btYrYz"
-                  :data {
-                   "D" {:type :leaf, :by "root", :at 1520961732826, :text "merge", :id "r1giTdtHYf"}
-                   "L" {:type :leaf, :by "root", :at 1521737796779, :text "ui/row", :id "Bktzxwb9f"}
-                   "T" {:type :leaf, :by "root", :at 1520875259977, :text "style-entry", :id "H1QgVZPNVtf"}
-                   "j" {
-                    :type :expr, :by "root", :at 1520961733434, :id "rJNaTdKSFM"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1520961734074, :text "if", :id "rympTdYBYz"}
-                     "j" {
-                      :type :expr, :by "root", :at 1520961736037, :id "HyexRdYBFf"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1520961735598, :text "=", :id "rJyC_YHKG"}
-                       "j" {:type :leaf, :by "root", :at 1520961798220, :text ":profile", :id "Bk-RdFrKG"}
+                       "T" {:type :leaf, :id "B1iaGcIexAHZ", :text "d!", :by "root", :at 1520875308253}
+                       "j" {:type :leaf, :id "H126zqIglRB-", :text ":router/change", :by "root", :at 1500541010211}
                        "r" {
-                        :type :expr, :by "root", :at 1520961762439, :id "ByS9kKKSYf"
+                        :type :expr, :id "Sy6pz58llCrW", :by nil, :at 1500541010211
                         :data {
-                         "T" {:type :leaf, :by "root", :at 1520961763035, :text ":name", :id "SkE5yttrKM"}
-                         "j" {:type :leaf, :by "root", :at 1520961763774, :text "router", :id "SkVoyKtrtf"}
-                        }
-                       }
-                      }
-                     }
-                     "r" {
-                      :type :expr, :by "root", :at 1520961766080, :id "S1bAkKYBYz"
-                      :data {
-                       "T" {:type :leaf, :by "root", :at 1520961765338, :text "{}", :id "S1xakKFBKf"}
-                       "j" {
-                        :type :expr, :by "root", :at 1520961767628, :id "B1ggYFBYf"
-                        :data {
-                         "T" {:type :leaf, :by "root", :at 1520961768841, :text ":color", :id "BkM01FFrKG"}
-                         "j" {:type :leaf, :by "root", :at 1520961771434, :text ":black", :id "SJM-eKYrKG"}
+                         "T" {:type :leaf, :id "SJRaG9IxlAB-", :text "{}", :by "root", :at 1500541010211}
+                         "j" {
+                          :type :expr, :id "BJk0zq8xxCr-", :by nil, :at 1500541010211
+                          :data {
+                           "T" {:type :leaf, :id "BJg0MqUxe0r-", :text ":name", :by "root", :at 1500541010211}
+                           "j" {:type :leaf, :id "SyWCG5IlgAS-", :text ":home", :by "root", :at 1500541010211}
+                          }
+                         }
                         }
                        }
                       }
@@ -7173,38 +6838,45 @@
                    }
                   }
                  }
-                }
-               }
-               "r" {
-                :type :expr, :id "SJeLFokgXG", :by nil, :at 1500541010211
-                :data {
-                 "T" {:type :leaf, :id "Hkc5MqUgeCBb", :text ":on-click", :by "root", :at 1514302332444}
-                 "j" {
-                  :type :expr, :by "root", :at 1520875332644, :id "BJlprDENKM"
+                 "r" {
+                  :type :expr, :by "root", :at 1520875268221, :id "SJhbw4Ntf"
                   :data {
-                   "D" {:type :leaf, :by "root", :at 1520875334033, :text "fn", :id "HybaHP4EYz"}
-                   "L" {
-                    :type :expr, :by "root", :at 1520875334361, :id "SymCrDN4Fz"
-                    :data {
-                     "T" {:type :leaf, :by "root", :at 1520875335369, :text "e", :id "HkMCSDEVFf"}
-                     "j" {:type :leaf, :by "root", :at 1520875336266, :text "d!", :id "r1MkIvNNFz"}
-                     "r" {:type :leaf, :by "root", :at 1520875337034, :text "m!", :id "HJWxUwENYf"}
-                    }
-                   }
+                   "D" {:type :leaf, :by "root", :at 1520875271640, :text ":style", :id "r10ZwNEKz"}
                    "T" {
-                    :type :expr, :id "B1irwE4Yf", :by nil, :at 1500541010211
+                    :type :expr, :by "root", :at 1520961731005, :id "ryxWtKrYz"
                     :data {
-                     "T" {:type :leaf, :id "HyvLfcIelAHb", :text "d!", :by "root", :at 1520875339293}
-                     "j" {:type :leaf, :id "r1_8fqLxgRHZ", :text ":router/change", :by "root", :at 1500541010211}
-                     "r" {
-                      :type :expr, :id "S1KIfc8xx0Sb", :by nil, :at 1500541010211
+                     "D" {:type :leaf, :by "root", :at 1520961732826, :text "merge", :id "r1giTdtHYf"}
+                     "L" {:type :leaf, :by "root", :at 1521737550897, :text "ui/row", :id "HkE81PW5f"}
+                     "T" {:type :leaf, :by "root", :at 1520875259977, :text "style-entry", :id "H1QgVZPNVtf"}
+                     "j" {
+                      :type :expr, :by "root", :at 1520961733434, :id "rJNaTdKSFM"
                       :data {
-                       "T" {:type :leaf, :id "BJqIM5LexCH-", :text "{}", :by "root", :at 1500541010211}
+                       "T" {:type :leaf, :by "root", :at 1520961734074, :text "if", :id "rympTdYBYz"}
                        "j" {
-                        :type :expr, :id "SyjIfc8ggAHZ", :by nil, :at 1500541010211
+                        :type :expr, :by "root", :at 1520961736037, :id "HyexRdYBFf"
                         :data {
-                         "T" {:type :leaf, :id "HJ3LM5LgxABb", :text ":name", :by "root", :at 1500541010211}
-                         "j" {:type :leaf, :id "rJT8GqIgxRr-", :text ":profile", :by "root", :at 1500541010211}
+                         "T" {:type :leaf, :by "root", :at 1520961735598, :text "=", :id "rJyC_YHKG"}
+                         "j" {:type :leaf, :by "root", :at 1520961788039, :text ":home", :id "Bk-RdFrKG"}
+                         "r" {
+                          :type :expr, :by "root", :at 1520961762439, :id "ByS9kKKSYf"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1520961763035, :text ":name", :id "SkE5yttrKM"}
+                           "j" {:type :leaf, :by "root", :at 1520961763774, :text "router", :id "SkVoyKtrtf"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "root", :at 1520961766080, :id "S1bAkKYBYz"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1520961765338, :text "{}", :id "S1xakKFBKf"}
+                         "j" {
+                          :type :expr, :by "root", :at 1520961767628, :id "B1ggYFBYf"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1520961768841, :text ":color", :id "BkM01FFrKG"}
+                           "j" {:type :leaf, :by "root", :at 1520961771434, :text ":black", :id "SJM-eKYrKG"}
+                          }
+                         }
                         }
                        }
                       }
@@ -7215,60 +6887,496 @@
                  }
                 }
                }
-              }
-             }
-             "v" {
-              :type :expr, :by "root", :at 1521737960247, :id "Syblx-v-5f"
-              :data {
-               "D" {:type :leaf, :by "root", :at 1521737961526, :text "div", :id "rkWxZDZ5M"}
-               "L" {
-                :type :expr, :by "root", :at 1521737961742, :id "B1ZGlZw-5f"
+               "r" {
+                :type :expr, :by "root", :at 1521737936096, :id "Skd0xv-cz"
                 :data {
-                 "T" {:type :leaf, :by "root", :at 1521737962582, :text "{}", :id "SkeMeWw-9f"}
-                 "j" {
-                  :type :expr, :by "root", :at 1521737962898, :id "Sy-XxWDZqG"
+                 "D" {:type :leaf, :by "root", :at 1521737937617, :text "div", :id "ByKAew-cG"}
+                 "L" {
+                  :type :expr, :by "root", :at 1521737937859, :id "HyzqClDbqf"
                   :data {
-                   "T" {:type :leaf, :by "root", :at 1521737963690, :text ":style", :id "rkg7ebDbqG"}
-                   "j" {:type :leaf, :by "root", :at 1521737967398, :text "style-icon", :id "SJWVxbDZ5M"}
+                   "T" {:type :leaf, :by "root", :at 1521737938184, :text "{}", :id "rk-c0xPZ9G"}
+                   "j" {
+                    :type :expr, :by "root", :at 1521737938459, :id "SkI9AgPZqz"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1521737943151, :text ":style", :id "B1HcRgDWqG"}
+                     "j" {:type :leaf, :by "root", :at 1521737945741, :text "style-icon", :id "SJxkZwbqG"}
+                    }
+                   }
+                  }
+                 }
+                 "f" {
+                  :type :expr, :by "root", :at 1520874796553, :id "BJwWWDWqM"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1520874797079, :text "comp-icon", :id "HJBNBE4tGleaf"}
+                   "j" {:type :leaf, :by "root", :at 1520874800662, :text ":home", :id "HkLNSNEKM"}
                   }
                  }
                 }
                }
-               "T" {
-                :type :expr, :by "root", :at 1520874934457, :id "S1eChr44tf"
+               "v" {
+                :type :expr, :by "root", :at 1521737552520, :id "rygQWZPb9z"
                 :data {
-                 "D" {:type :leaf, :by "root", :at 1520874935084, :text "if", :id "Hy1pSVEFz"}
-                 "L" {:type :leaf, :by "root", :at 1520874937708, :text "logged-in?", :id "SJGypSVVFM"}
+                 "T" {:type :leaf, :by "root", :at 1521737552828, :text "<>", :id "ByFL1vZ9Mleaf"}
+                 "j" {
+                  :type :expr, :by "root", :at 1521737554545, :id "H1jLJvW9M"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1521737557214, :text ":working", :id "Sy7KU1P-cf"}
+                   "j" {:type :leaf, :by "root", :at 1521737558836, :text "numbers", :id "BkC81w-qz"}
+                  }
+                 }
+                 "r" {:type :leaf, :by "root", :at 1521737853644, :text "style-count", :id "rylrFewWqG"}
+                }
+               }
+              }
+             }
+             "j" {
+              :type :expr, :id "SyMsUENFG", :by nil, :at 1500541010211
+              :data {
+               "T" {:type :leaf, :id "Hk3dfcUex0rW", :text "div", :by "root", :at 1500541010211}
+               "j" {
+                :type :expr, :id "BJT_z5UgeRB-", :by nil, :at 1500541010211
+                :data {
+                 "T" {:type :leaf, :id "rkCufcIex0rb", :text "{}", :by "root", :at 1500541010211}
+                 "j" {
+                  :type :expr, :id "BkxztoJgmz", :by nil, :at 1500541010211
+                  :data {
+                   "T" {:type :leaf, :id "SJVtzcUllCSW", :text ":on-click", :by "root", :at 1514302328636}
+                   "j" {
+                    :type :expr, :by "root", :at 1520875297716, :id "BJePNw4EKG"
+                    :data {
+                     "T" {:type :leaf, :id "BkSFGqIelRSb", :text "fn", :by "root", :at 1520875299130}
+                     "j" {
+                      :type :expr, :by "root", :at 1520875299945, :id "Byh7wVNFz"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1520875301244, :text "e", :id "HJeoQDV4tf"}
+                       "j" {:type :leaf, :by "root", :at 1520875303034, :text "d!", :id "Hke6QvNNKf"}
+                       "r" {:type :leaf, :by "root", :at 1520875303747, :text "m!", :id "SyZkNwENKG"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :id "S1l-NDVEtf", :by nil, :at 1500541010211
+                      :data {
+                       "T" {:type :leaf, :id "B1iaGcIexAHZ", :text "d!", :by "root", :at 1520875308253}
+                       "j" {:type :leaf, :id "H126zqIglRB-", :text ":router/change", :by "root", :at 1500541010211}
+                       "r" {
+                        :type :expr, :id "Sy6pz58llCrW", :by nil, :at 1500541010211
+                        :data {
+                         "T" {:type :leaf, :id "SJRaG9IxlAB-", :text "{}", :by "root", :at 1500541010211}
+                         "j" {
+                          :type :expr, :id "BJk0zq8xxCr-", :by nil, :at 1500541010211
+                          :data {
+                           "T" {:type :leaf, :id "BJg0MqUxe0r-", :text ":name", :by "root", :at 1500541010211}
+                           "j" {:type :leaf, :id "SyWCG5IlgAS-", :text ":pending", :by "root", :at 1520962777871}
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "root", :at 1520875268221, :id "S1gffDNEKz"
+                  :data {
+                   "D" {:type :leaf, :by "root", :at 1520875271640, :text ":style", :id "r10ZwNEKz"}
+                   "T" {
+                    :type :expr, :by "root", :at 1520961731005, :id "SkjTOFSKG"
+                    :data {
+                     "D" {:type :leaf, :by "root", :at 1520961732826, :text "merge", :id "r1giTdtHYf"}
+                     "L" {:type :leaf, :by "root", :at 1521737624674, :text "ui/row", :id "r1lR9kw-5G"}
+                     "T" {:type :leaf, :by "root", :at 1520875259977, :text "style-entry", :id "H1QgVZPNVtf"}
+                     "j" {
+                      :type :expr, :by "root", :at 1520961733434, :id "rJNaTdKSFM"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1520961734074, :text "if", :id "rympTdYBYz"}
+                       "j" {
+                        :type :expr, :by "root", :at 1520961736037, :id "HyexRdYBFf"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1520961735598, :text "=", :id "rJyC_YHKG"}
+                         "j" {:type :leaf, :by "root", :at 1520962782647, :text ":pending", :id "Bk-RdFrKG"}
+                         "r" {
+                          :type :expr, :by "root", :at 1520961762439, :id "ByS9kKKSYf"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1520961763035, :text ":name", :id "SkE5yttrKM"}
+                           "j" {:type :leaf, :by "root", :at 1520961763774, :text "router", :id "SkVoyKtrtf"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "root", :at 1520961766080, :id "S1bAkKYBYz"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1520961765338, :text "{}", :id "S1xakKFBKf"}
+                         "j" {
+                          :type :expr, :by "root", :at 1520961767628, :id "B1ggYFBYf"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1520961768841, :text ":color", :id "BkM01FFrKG"}
+                           "j" {:type :leaf, :by "root", :at 1520961771434, :text ":black", :id "SJM-eKYrKG"}
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "n" {
+                :type :expr, :by "root", :at 1521737936096, :id "H1bH1bDWqM"
+                :data {
+                 "D" {:type :leaf, :by "root", :at 1521737937617, :text "div", :id "ByKAew-cG"}
+                 "L" {
+                  :type :expr, :by "root", :at 1521737937859, :id "HyzqClDbqf"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1521737938184, :text "{}", :id "rk-c0xPZ9G"}
+                   "j" {
+                    :type :expr, :by "root", :at 1521737938459, :id "SkI9AgPZqz"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1521737943151, :text ":style", :id "B1HcRgDWqG"}
+                     "j" {:type :leaf, :by "root", :at 1521737945741, :text "style-icon", :id "SJxkZwbqG"}
+                    }
+                   }
+                  }
+                 }
                  "T" {
-                  :type :expr, :by "root", :at 1520874915087, :id "B1ooSNNFM"
+                  :type :expr, :by "root", :at 1520874796553, :id "Byzpgbv-qz"
                   :data {
-                   "T" {:type :leaf, :by "root", :at 1520874917648, :text "comp-icon", :id "B1ooSNNFMleaf"}
-                   "j" {:type :leaf, :by "root", :at 1520874925094, :text ":ios-contact", :id "ryz0jHNEFf"}
+                   "T" {:type :leaf, :by "root", :at 1520874797079, :text "comp-icon", :id "HJBNBE4tGleaf"}
+                   "j" {:type :leaf, :by "root", :at 1520875172462, :text ":ios-time-outline", :id "HkLNSNEKM"}
                   }
                  }
+                }
+               }
+               "v" {
+                :type :expr, :by "root", :at 1521737629299, :id "BJeSskwZcz"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1521737629893, :text "<>", :id "BJeSskwZczleaf"}
                  "j" {
-                  :type :expr, :by "root", :at 1520874941424, :id "BySTHV4tM"
+                  :type :expr, :by "root", :at 1521737630263, :id "BJGIsyv-cf"
                   :data {
-                   "T" {:type :leaf, :by "root", :at 1520874981330, :text "comp-icon", :id "HkWmpSE4FG"}
-                   "j" {:type :leaf, :by "root", :at 1520874975369, :text ":log-in", :id "rJfJUVVtz"}
+                   "T" {:type :leaf, :by "root", :at 1521737632367, :text ":pending", :id "SJ-LokwWqM"}
+                   "j" {:type :leaf, :by "root", :at 1521737635823, :text "numbers", :id "rJ9oJvWqf"}
                   }
                  }
+                 "r" {:type :leaf, :by "root", :at 1521737858250, :text "style-count", :id "HJeqYlDW9G"}
                 }
                }
               }
              }
-             "x" {
-              :type :expr, :by "root", :at 1521220026009, :id "SJA21P-qG"
+             "r" {
+              :type :expr, :id "ByMeP4VYM", :by nil, :at 1500541010211
               :data {
-               "D" {:type :leaf, :by "root", :at 1521220028997, :text "<>", :id "HJ4aYOKYM"}
-               "T" {
-                :type :expr, :by "root", :at 1521737526453, :id "Bk7A4yDb9M"
+               "T" {:type :leaf, :id "Hk3dfcUex0rW", :text "div", :by "root", :at 1500541010211}
+               "j" {
+                :type :expr, :id "BJT_z5UgeRB-", :by nil, :at 1500541010211
                 :data {
-                 "T" {:type :leaf, :by "root", :at 1521737530051, :text ":sessions", :id "rkxf6Y_Ktzleaf"}
-                 "j" {:type :leaf, :by "root", :at 1521737533436, :text "numbers", :id "rJ7rJDWcz"}
+                 "T" {:type :leaf, :id "rkCufcIex0rb", :text "{}", :by "root", :at 1500541010211}
+                 "j" {
+                  :type :expr, :id "BkxztoJgmz", :by nil, :at 1500541010211
+                  :data {
+                   "T" {:type :leaf, :id "SJVtzcUllCSW", :text ":on-click", :by "root", :at 1514302328636}
+                   "j" {
+                    :type :expr, :by "root", :at 1520875297716, :id "H1xdVwEVKM"
+                    :data {
+                     "T" {:type :leaf, :id "BkSFGqIelRSb", :text "fn", :by "root", :at 1520875299130}
+                     "j" {
+                      :type :expr, :by "root", :at 1520875299945, :id "Byh7wVNFz"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1520875301244, :text "e", :id "HJeoQDV4tf"}
+                       "j" {:type :leaf, :by "root", :at 1520875303034, :text "d!", :id "Hke6QvNNKf"}
+                       "r" {:type :leaf, :by "root", :at 1520875303747, :text "m!", :id "SyZkNwENKG"}
+                      }
+                     }
+                     "r" {
+                      :type :expr, :id "S1l-NDVEtf", :by nil, :at 1500541010211
+                      :data {
+                       "T" {:type :leaf, :id "B1iaGcIexAHZ", :text "d!", :by "root", :at 1520875308253}
+                       "j" {:type :leaf, :id "H126zqIglRB-", :text ":router/change", :by "root", :at 1500541010211}
+                       "r" {
+                        :type :expr, :id "Sy6pz58llCrW", :by nil, :at 1500541010211
+                        :data {
+                         "T" {:type :leaf, :id "SJRaG9IxlAB-", :text "{}", :by "root", :at 1500541010211}
+                         "j" {
+                          :type :expr, :id "BJk0zq8xxCr-", :by nil, :at 1500541010211
+                          :data {
+                           "T" {:type :leaf, :id "BJg0MqUxe0r-", :text ":name", :by "root", :at 1500541010211}
+                           "j" {:type :leaf, :id "SyWCG5IlgAS-", :text ":done", :by "root", :at 1520875322006}
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "r" {
+                  :type :expr, :by "root", :at 1520875268221, :id "SylXfvNEtG"
+                  :data {
+                   "D" {:type :leaf, :by "root", :at 1520875271640, :text ":style", :id "r10ZwNEKz"}
+                   "T" {
+                    :type :expr, :by "root", :at 1520961731005, :id "BycxKKSYG"
+                    :data {
+                     "D" {:type :leaf, :by "root", :at 1520961732826, :text "merge", :id "r1giTdtHYf"}
+                     "L" {:type :leaf, :by "root", :at 1521737642779, :text "ui/row", :id "B1fnywW5M"}
+                     "T" {:type :leaf, :by "root", :at 1520875259977, :text "style-entry", :id "H1QgVZPNVtf"}
+                     "j" {
+                      :type :expr, :by "root", :at 1520961733434, :id "rJNaTdKSFM"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1520961734074, :text "if", :id "rympTdYBYz"}
+                       "j" {
+                        :type :expr, :by "root", :at 1520961736037, :id "HyexRdYBFf"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1520961735598, :text "=", :id "rJyC_YHKG"}
+                         "j" {:type :leaf, :by "root", :at 1520961781293, :text ":done", :id "Bk-RdFrKG"}
+                         "r" {
+                          :type :expr, :by "root", :at 1520961762439, :id "ByS9kKKSYf"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1520961763035, :text ":name", :id "SkE5yttrKM"}
+                           "j" {:type :leaf, :by "root", :at 1520961763774, :text "router", :id "SkVoyKtrtf"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "root", :at 1520961766080, :id "S1bAkKYBYz"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1520961765338, :text "{}", :id "S1xakKFBKf"}
+                         "j" {
+                          :type :expr, :by "root", :at 1520961767628, :id "B1ggYFBYf"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1520961768841, :text ":color", :id "BkM01FFrKG"}
+                           "j" {:type :leaf, :by "root", :at 1520961771434, :text ":black", :id "SJM-eKYrKG"}
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
                 }
                }
-               "j" {:type :leaf, :by "root", :at 1521737849364, :text "style-count", :id "Hymktevb5M"}
+               "n" {
+                :type :expr, :by "root", :at 1521737936096, :id "B1b2y-Pb5G"
+                :data {
+                 "D" {:type :leaf, :by "root", :at 1521737937617, :text "div", :id "ByKAew-cG"}
+                 "L" {
+                  :type :expr, :by "root", :at 1521737937859, :id "HyzqClDbqf"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1521737938184, :text "{}", :id "rk-c0xPZ9G"}
+                   "j" {
+                    :type :expr, :by "root", :at 1521737938459, :id "SkI9AgPZqz"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1521737943151, :text ":style", :id "B1HcRgDWqG"}
+                     "j" {:type :leaf, :by "root", :at 1521737945741, :text "style-icon", :id "SJxkZwbqG"}
+                    }
+                   }
+                  }
+                 }
+                 "T" {
+                  :type :expr, :by "root", :at 1520874796553, :id "H1ejgbDZ9M"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1520874797079, :text "comp-icon", :id "HJBNBE4tGleaf"}
+                   "j" {:type :leaf, :by "root", :at 1520875245380, :text ":social-buffer", :id "HkLNSNEKM"}
+                  }
+                 }
+                }
+               }
+               "v" {
+                :type :expr, :by "root", :at 1521737644212, :id "SkgVnkP-9f"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1521737644918, :text "<>", :id "SkgVnkP-9fleaf"}
+                 "j" {
+                  :type :expr, :by "root", :at 1521737646014, :id "SygIhJv-qG"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1521737646552, :text ":done", :id "H1Zr3yDZcM"}
+                   "j" {:type :leaf, :by "root", :at 1521737647861, :text "numbers", :id "Syxw3ywZ9z"}
+                  }
+                 }
+                 "r" {:type :leaf, :by "root", :at 1521737862971, :text "style-count", :id "rJ1cgv-cf"}
+                }
+               }
+              }
+             }
+            }
+           }
+           "v" {
+            :type :expr, :by "root", :at 1521220013466, :id "SyHnKdYFz"
+            :data {
+             "D" {:type :leaf, :by "root", :at 1521220014248, :text "div", :id "rk82Y_YKM"}
+             "L" {
+              :type :expr, :by "root", :at 1521220014493, :id "HkVIhK_FKM"
+              :data {
+               "T" {:type :leaf, :by "root", :at 1521220014882, :text "{}", :id "rJXIhKOYKG"}
+               "j" {
+                :type :expr, :by "root", :at 1521220018728, :id "SJ-i3Y_KFM"
+                :data {
+                 "T" {:type :leaf, :by "root", :at 1521220019636, :text ":style", :id "Hyo3tuYFz"}
+                 "j" {:type :leaf, :by "root", :at 1521220022388, :text "ui/column", :id "Bkx33F_KYM"}
+                }
+               }
+              }
+             }
+             "T" {
+              :type :expr, :id "H10FM9IeeRBb", :by nil, :at 1500541010211
+              :data {
+               "T" {:type :leaf, :id "ByyqzcUglRHZ", :text "div", :by "root", :at 1500541010211}
+               "j" {
+                :type :expr, :id "rkl5GcLglABW", :by nil, :at 1500541010211
+                :data {
+                 "T" {:type :leaf, :id "HybqMqUge0SW", :text "{}", :by "root", :at 1500541010211}
+                 "j" {
+                  :type :expr, :by "root", :at 1520875268221, :id "HkeLzvEEFM"
+                  :data {
+                   "D" {:type :leaf, :by "root", :at 1520875271640, :text ":style", :id "r10ZwNEKz"}
+                   "T" {
+                    :type :expr, :by "root", :at 1520961731005, :id "Sk5btYrYz"
+                    :data {
+                     "D" {:type :leaf, :by "root", :at 1520961732826, :text "merge", :id "r1giTdtHYf"}
+                     "L" {:type :leaf, :by "root", :at 1521737796779, :text "ui/row", :id "Bktzxwb9f"}
+                     "T" {:type :leaf, :by "root", :at 1520875259977, :text "style-entry", :id "H1QgVZPNVtf"}
+                     "j" {
+                      :type :expr, :by "root", :at 1520961733434, :id "rJNaTdKSFM"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1520961734074, :text "if", :id "rympTdYBYz"}
+                       "j" {
+                        :type :expr, :by "root", :at 1520961736037, :id "HyexRdYBFf"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1520961735598, :text "=", :id "rJyC_YHKG"}
+                         "j" {:type :leaf, :by "root", :at 1520961798220, :text ":profile", :id "Bk-RdFrKG"}
+                         "r" {
+                          :type :expr, :by "root", :at 1520961762439, :id "ByS9kKKSYf"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1520961763035, :text ":name", :id "SkE5yttrKM"}
+                           "j" {:type :leaf, :by "root", :at 1520961763774, :text "router", :id "SkVoyKtrtf"}
+                          }
+                         }
+                        }
+                       }
+                       "r" {
+                        :type :expr, :by "root", :at 1520961766080, :id "S1bAkKYBYz"
+                        :data {
+                         "T" {:type :leaf, :by "root", :at 1520961765338, :text "{}", :id "S1xakKFBKf"}
+                         "j" {
+                          :type :expr, :by "root", :at 1520961767628, :id "B1ggYFBYf"
+                          :data {
+                           "T" {:type :leaf, :by "root", :at 1520961768841, :text ":color", :id "BkM01FFrKG"}
+                           "j" {:type :leaf, :by "root", :at 1520961771434, :text ":black", :id "SJM-eKYrKG"}
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                 "r" {
+                  :type :expr, :id "SJeLFokgXG", :by nil, :at 1500541010211
+                  :data {
+                   "T" {:type :leaf, :id "Hkc5MqUgeCBb", :text ":on-click", :by "root", :at 1514302332444}
+                   "j" {
+                    :type :expr, :by "root", :at 1520875332644, :id "BJlprDENKM"
+                    :data {
+                     "D" {:type :leaf, :by "root", :at 1520875334033, :text "fn", :id "HybaHP4EYz"}
+                     "L" {
+                      :type :expr, :by "root", :at 1520875334361, :id "SymCrDN4Fz"
+                      :data {
+                       "T" {:type :leaf, :by "root", :at 1520875335369, :text "e", :id "HkMCSDEVFf"}
+                       "j" {:type :leaf, :by "root", :at 1520875336266, :text "d!", :id "r1MkIvNNFz"}
+                       "r" {:type :leaf, :by "root", :at 1520875337034, :text "m!", :id "HJWxUwENYf"}
+                      }
+                     }
+                     "T" {
+                      :type :expr, :id "B1irwE4Yf", :by nil, :at 1500541010211
+                      :data {
+                       "T" {:type :leaf, :id "HyvLfcIelAHb", :text "d!", :by "root", :at 1520875339293}
+                       "j" {:type :leaf, :id "r1_8fqLxgRHZ", :text ":router/change", :by "root", :at 1500541010211}
+                       "r" {
+                        :type :expr, :id "S1KIfc8xx0Sb", :by nil, :at 1500541010211
+                        :data {
+                         "T" {:type :leaf, :id "BJqIM5LexCH-", :text "{}", :by "root", :at 1500541010211}
+                         "j" {
+                          :type :expr, :id "SyjIfc8ggAHZ", :by nil, :at 1500541010211
+                          :data {
+                           "T" {:type :leaf, :id "HJ3LM5LgxABb", :text ":name", :by "root", :at 1500541010211}
+                           "j" {:type :leaf, :id "rJT8GqIgxRr-", :text ":profile", :by "root", :at 1500541010211}
+                          }
+                         }
+                        }
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "v" {
+                :type :expr, :by "root", :at 1521737960247, :id "Syblx-v-5f"
+                :data {
+                 "D" {:type :leaf, :by "root", :at 1521737961526, :text "div", :id "rkWxZDZ5M"}
+                 "L" {
+                  :type :expr, :by "root", :at 1521737961742, :id "B1ZGlZw-5f"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1521737962582, :text "{}", :id "SkeMeWw-9f"}
+                   "j" {
+                    :type :expr, :by "root", :at 1521737962898, :id "Sy-XxWDZqG"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1521737963690, :text ":style", :id "rkg7ebDbqG"}
+                     "j" {:type :leaf, :by "root", :at 1521737967398, :text "style-icon", :id "SJWVxbDZ5M"}
+                    }
+                   }
+                  }
+                 }
+                 "T" {
+                  :type :expr, :by "root", :at 1520874934457, :id "S1eChr44tf"
+                  :data {
+                   "D" {:type :leaf, :by "root", :at 1520874935084, :text "if", :id "Hy1pSVEFz"}
+                   "L" {:type :leaf, :by "root", :at 1520874937708, :text "logged-in?", :id "SJGypSVVFM"}
+                   "T" {
+                    :type :expr, :by "root", :at 1520874915087, :id "B1ooSNNFM"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1520874917648, :text "comp-icon", :id "B1ooSNNFMleaf"}
+                     "j" {:type :leaf, :by "root", :at 1520874925094, :text ":ios-contact", :id "ryz0jHNEFf"}
+                    }
+                   }
+                   "j" {
+                    :type :expr, :by "root", :at 1520874941424, :id "BySTHV4tM"
+                    :data {
+                     "T" {:type :leaf, :by "root", :at 1520874981330, :text "comp-icon", :id "HkWmpSE4FG"}
+                     "j" {:type :leaf, :by "root", :at 1520874975369, :text ":log-in", :id "rJfJUVVtz"}
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+               "x" {
+                :type :expr, :by "root", :at 1521220026009, :id "SJA21P-qG"
+                :data {
+                 "D" {:type :leaf, :by "root", :at 1521220028997, :text "<>", :id "HJ4aYOKYM"}
+                 "T" {
+                  :type :expr, :by "root", :at 1521737526453, :id "Bk7A4yDb9M"
+                  :data {
+                   "T" {:type :leaf, :by "root", :at 1521737530051, :text ":sessions", :id "rkxf6Y_Ktzleaf"}
+                   "j" {:type :leaf, :by "root", :at 1521737533436, :text "numbers", :id "rJ7rJDWcz"}
+                  }
+                 }
+                 "j" {:type :leaf, :by "root", :at 1521737849364, :text "style-count", :id "Hymktevb5M"}
+                }
+               }
               }
              }
             }
@@ -7358,6 +7466,13 @@
            "j" {:type :leaf, :by "root", :at 1521738051848, :text "40", :id "BkSsSbvbqM"}
           }
          }
+         "yj" {
+          :type :expr, :by "root", :at 1531641231416, :id "Bylv5TdOmX"
+          :data {
+           "T" {:type :leaf, :by "root", :at 1531641233970, :text ":margin-right", :id "Bylv5TdOmXleaf"}
+           "j" {:type :leaf, :by "root", :at 1531641238421, :text "24", :id "HJV9qp_dQX"}
+          }
+         }
         }
        }
       }
@@ -7380,7 +7495,7 @@
             :type :expr, :by "root", :at 1521737988866, :id "BJaW-w-qG"
             :data {
              "T" {:type :leaf, :by "root", :at 1521737990430, :text ":width", :id "SJWnZbwb5f"}
-             "j" {:type :leaf, :by "root", :at 1521738025740, :text "32", :id "rkkM-PZ9f"}
+             "j" {:type :leaf, :by "root", :at 1531641210553, :text "24", :id "rkkM-PZ9f"}
             }
            }
           }

--- a/package.json
+++ b/package.json
@@ -19,15 +19,15 @@
   "author": "jiyinyiyong",
   "license": "MIT",
   "dependencies": {
-    "dayjs": "^1.6.10",
+    "dayjs": "^1.7.4",
     "md5": "^2.2.1",
     "randomcolor": "^0.5.3",
-    "shortid": "^2.2.6"
+    "shortid": "^2.2.12"
   },
   "devDependencies": {
     "http-server": "^0.11.1",
-    "shadow-cljs": "^2.4.16",
+    "shadow-cljs": "^2.4.20",
     "source-map-support": "^0.5.6",
-    "ws": "^5.2.1"
+    "ws": "^5.2.2"
   }
 }

--- a/src/app/comp/container.cljs
+++ b/src/app/comp/container.cljs
@@ -49,17 +49,21 @@
    (if (nil? store)
      (comp-offline)
      (div
-      {:style (merge ui/global ui/fullscreen ui/row)}
+      {:style (merge ui/global ui/fullscreen ui/column)}
       (comp-sidebar (:router store) (:logged-in? store) (:numbers store))
-      (if (:logged-in? store)
-        (let [router (:router store)]
-          (case (:name router)
-            :profile (comp-profile (:user store))
-            :home (cursor-> :home comp-home states (:data router))
-            :pending (cursor-> :pending comp-pending states (:data router))
-            :done (cursor-> :done comp-done-tasks states (:data router))
-            (<> router nil)))
-        (comp-login states))
+      (div
+       {:style {:overflow :auto}}
+       (div
+        {:style {:margin "0 auto", :max-width 800}}
+        (if (:logged-in? store)
+          (let [router (:router store)]
+            (case (:name router)
+              :profile (comp-profile (:user store))
+              :home (cursor-> :home comp-home states (:data router))
+              :pending (cursor-> :pending comp-pending states (:data router))
+              :done (cursor-> :done comp-done-tasks states (:data router))
+              (<> router nil)))
+          (comp-login states))))
       (comp-msg-list (get-in store [:session :notifications]) :session/remove-notification)
       (comp-status-color (:color store))
       (if dev? (comp-inspect "Store" store style-debugger))

--- a/src/app/comp/done_tasks.cljs
+++ b/src/app/comp/done_tasks.cljs
@@ -52,7 +52,7 @@
     (div
      {}
      (<>
-      (str "Done Tasks(" (count router-data) ")")
+      (str "Done Tasks(" (count tasks) ")")
       {:font-size 24, :font-family ui/font-fancy, :font-weight 100})
      (=< 16 nil)
      (if (:editing? state)

--- a/src/app/comp/done_tasks.cljs
+++ b/src/app/comp/done_tasks.cljs
@@ -48,38 +48,37 @@
        months (:months router-data)
        tasks (:tasks router-data)]
    (div
-    {:style (merge ui/flex {:padding 16, :overflow :auto})}
+    {:style (merge ui/flex ui/row {:padding 16})}
+    (list->
+     {:style {:overflow :auto, :font-family ui/font-fancy, :max-height 320}}
+     (->> months
+          (map
+           (fn [year-month]
+             [year-month
+              (div
+               {:style (merge
+                        {:cursor :pointer, :padding "0 18px"}
+                        (when (= cursor year-month) {:background-color (hsl 0 0 90)})),
+                :on-click (fn [e d! m!] (d! :router/change {:name :done, :data year-month}))}
+               (<> year-month))]))))
+    (=< 16 nil)
     (div
-     {}
-     (<>
-      (str "Done Tasks(" (count tasks) ")")
-      {:font-size 24, :font-family ui/font-fancy, :font-weight 100})
-     (=< 16 nil)
-     (if (:editing? state)
-       (a
-        {:style ui/link,
-         :inner-text "Done",
-         :on-click (mutation-> (update state :editing? not))})
-       (a
-        {:style ui/link,
-         :inner-text "Edit",
-         :on-click (mutation-> (update state :editing? not))})))
-    (div
-     {:style ui/row}
-     (list->
-      {:style {:overflow :auto, :font-family ui/font-fancy, :max-height 320}}
-      (->> months
-           (map
-            (fn [year-month]
-              [year-month
-               (div
-                {:style (merge
-                         {:cursor :pointer, :padding "0 18px"}
-                         (when (= cursor year-month) {:background-color (hsl 0 0 90)})),
-                 :on-click (fn [e d! m!]
-                   (d! :router/change {:name :done, :data year-month}))}
-                (<> year-month))]))))
-     (=< 16 nil)
+     {:style ui/column}
+     (div
+      {}
+      (<>
+       (str "Done Tasks(" (count tasks) ")")
+       {:font-size 24, :font-family ui/font-fancy, :font-weight 100})
+      (=< 16 nil)
+      (if (:editing? state)
+        (a
+         {:style ui/link,
+          :inner-text "Done",
+          :on-click (mutation-> (update state :editing? not))})
+        (a
+         {:style ui/link,
+          :inner-text "Edit",
+          :on-click (mutation-> (update state :editing? not))})))
      (let [tasks-by-time (->> tasks
                               vals
                               (group-by (fn [task] (.format (dayjs (:time task)) "DD"))))]

--- a/src/app/comp/done_tasks.cljs
+++ b/src/app/comp/done_tasks.cljs
@@ -102,6 +102,7 @@
                   (list->
                    {}
                    (->> tasks
+                        (sort-by (fn [task] (unchecked-negate (:time task))))
                         (map
                          (fn [task] [(:id task) (comp-done-task task (:editing? state))])))))]))))))
     (comment

--- a/src/app/comp/done_tasks.cljs
+++ b/src/app/comp/done_tasks.cljs
@@ -5,13 +5,13 @@
             [respo-ui.colors :as colors]
             [respo.macros
              :refer
-             [defcomp <> div span cursor-> mutation-> button list-> action-> input a]]
+             [defcomp <> div span cursor-> mutation-> button list-> action-> input a pre]]
             [respo.comp.inspect :refer [comp-inspect]]
             [respo.comp.space :refer [=<]]
             [app.comp.reel :refer [comp-reel]]
             [respo.util.list :refer [map-val]]
             [respo-ui.comp.icon :refer [comp-icon]]
-            [app.util :refer [format-date]]))
+            ["dayjs" :as dayjs]))
 
 (defcomp
  comp-done-task
@@ -43,7 +43,10 @@
 (defcomp
  comp-done-tasks
  (states router-data)
- (let [state (or (:data states) {:editing? false})]
+ (let [state (or (:data states) {:editing? false})
+       cursor (:cursor router-data)
+       months (:months router-data)
+       tasks (:tasks router-data)]
    (div
     {:style (merge ui/flex {:padding 16, :overflow :auto})}
     (div
@@ -61,30 +64,46 @@
         {:style ui/link,
          :inner-text "Edit",
          :on-click (mutation-> (update state :editing? not))})))
-    (let [tasks-by-time (->> router-data
-                             vals
-                             (group-by (fn [task] (format-date (:time task)))))]
-      (list->
-       {}
-       (->> tasks-by-time
-            (sort (fn [pair-a pair-b] (compare (first pair-b) (first pair-a))))
-            (map
-             (fn [[date tasks]]
-               [date
-                (div
-                 {}
+    (div
+     {:style ui/row}
+     (list->
+      {:style {:overflow :auto, :font-family ui/font-fancy, :max-height 320}}
+      (->> months
+           (map
+            (fn [year-month]
+              [year-month
+               (div
+                {:style (merge
+                         {:cursor :pointer, :padding "0 18px"}
+                         (when (= cursor year-month) {:background-color (hsl 0 0 90)})),
+                 :on-click (fn [e d! m!]
+                   (d! :router/change {:name :done, :data year-month}))}
+                (<> year-month))]))))
+     (=< 16 nil)
+     (let [tasks-by-time (->> tasks
+                              vals
+                              (group-by (fn [task] (.format (dayjs (:time task)) "DD"))))]
+       (list->
+        {}
+        (->> tasks-by-time
+             (sort (fn [pair-a pair-b] (compare (first pair-b) (first pair-a))))
+             (map
+              (fn [[date tasks]]
+                [date
                  (div
-                  {:style {:font-family ui/font-fancy,
-                           :font-size 16,
-                           :font-weight 100,
-                           :margin-top 16,
-                           :line-height "24px"}}
-                  (<> date))
-                 (list->
                   {}
-                  (->> tasks
-                       (map
-                        (fn [task] [(:id task) (comp-done-task task (:editing? state))])))))])))))
+                  (div
+                   {:style {:font-family ui/font-fancy,
+                            :font-size 16,
+                            :font-weight 100,
+                            :margin-top 16,
+                            :line-height "24px"}}
+                   (<> date))
+                  (list->
+                   {}
+                   (->> tasks
+                        (map
+                         (fn [task] [(:id task) (comp-done-task task (:editing? state))])))))]))))))
     (comment
      if
      (pos? (count router-data))

--- a/src/app/comp/sidebar.cljs
+++ b/src/app/comp/sidebar.cljs
@@ -8,41 +8,45 @@
 
 (def style-count (merge ui/center {:width 20, :font-size 14}))
 
-(def style-entry {:cursor :pointer, :color (hsl 0 0 60), :align-items :center, :height 40})
+(def style-entry
+  {:cursor :pointer, :color (hsl 0 0 60), :align-items :center, :height 40, :margin-right 24})
 
-(def style-icon (merge ui/center {:width 32}))
+(def style-icon (merge ui/center {:width 24}))
 
 (defcomp
  comp-sidebar
  (router logged-in? numbers)
  (div
-  {:style (merge
-           ui/column-parted
-           {:font-size 24,
-            :border-right (str "1px solid " (hsl 0 0 0 0.1)),
-            :font-family ui/font-fancy,
-            :padding "8 8px"})}
+  {:style {:flex-shrink 0, :border-bottom (str "1px solid " (hsl 0 0 90))}}
   (div
-   {:style {}}
+   {:style (merge
+            ui/row-parted
+            {:font-size 24,
+             :font-family ui/font-fancy,
+             :padding "8 8px",
+             :max-width 800,
+             :margin :auto})}
    (div
-    {:on-click (fn [e d! m!] (d! :router/change {:name :home})),
-     :style (merge ui/row style-entry (if (= :home (:name router)) {:color :black}))}
-    (div {:style style-icon} (comp-icon :home))
-    (<> (:working numbers) style-count))
+    {:style ui/row}
+    (div
+     {:on-click (fn [e d! m!] (d! :router/change {:name :home})),
+      :style (merge ui/row style-entry (if (= :home (:name router)) {:color :black}))}
+     (div {:style style-icon} (comp-icon :home))
+     (<> (:working numbers) style-count))
+    (div
+     {:on-click (fn [e d! m!] (d! :router/change {:name :pending})),
+      :style (merge ui/row style-entry (if (= :pending (:name router)) {:color :black}))}
+     (div {:style style-icon} (comp-icon :ios-time-outline))
+     (<> (:pending numbers) style-count))
+    (div
+     {:on-click (fn [e d! m!] (d! :router/change {:name :done})),
+      :style (merge ui/row style-entry (if (= :done (:name router)) {:color :black}))}
+     (div {:style style-icon} (comp-icon :social-buffer))
+     (<> (:done numbers) style-count)))
    (div
-    {:on-click (fn [e d! m!] (d! :router/change {:name :pending})),
-     :style (merge ui/row style-entry (if (= :pending (:name router)) {:color :black}))}
-    (div {:style style-icon} (comp-icon :ios-time-outline))
-    (<> (:pending numbers) style-count))
-   (div
-    {:on-click (fn [e d! m!] (d! :router/change {:name :done})),
-     :style (merge ui/row style-entry (if (= :done (:name router)) {:color :black}))}
-    (div {:style style-icon} (comp-icon :social-buffer))
-    (<> (:done numbers) style-count)))
-  (div
-   {:style ui/column}
-   (div
-    {:style (merge ui/row style-entry (if (= :profile (:name router)) {:color :black})),
-     :on-click (fn [e d! m!] (d! :router/change {:name :profile}))}
-    (div {:style style-icon} (if logged-in? (comp-icon :ios-contact) (comp-icon :log-in)))
-    (<> (:sessions numbers) style-count)))))
+    {:style ui/column}
+    (div
+     {:style (merge ui/row style-entry (if (= :profile (:name router)) {:color :black})),
+      :on-click (fn [e d! m!] (d! :router/change {:name :profile}))}
+     (div {:style style-icon} (if logged-in? (comp-icon :ios-contact) (comp-icon :log-in)))
+     (<> (:sessions numbers) style-count))))))

--- a/src/app/schema.cljs
+++ b/src/app/schema.cljs
@@ -14,7 +14,7 @@
 (def session
   {:user-id nil, :id nil, :nickname nil, :router {:name :home, :data nil}, :notifications []})
 
-(def task {:id nil, :text "", :text-time ""})
+(def task {:id nil, :text "", :mode nil, :time 0})
 
 (def user
   {:name nil,

--- a/src/app/util.cljs
+++ b/src/app/util.cljs
@@ -2,5 +2,3 @@
 (ns app.util (:require ["dayjs" :as dayjs]))
 
 (defn find-first [f xs] (reduce (fn [_ x] (when (f x) (reduced x))) nil xs))
-
-(defn format-date [unix-time] (.format (dayjs unix-time) "YYYY-MM-DD"))

--- a/yarn.lock
+++ b/yarn.lock
@@ -702,9 +702,9 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-dayjs@^1.6.10:
-  version "1.6.10"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.6.10.tgz#8725191b9a7a5f8c2bf42d0cb6e8df1a041d3274"
+dayjs@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.7.4.tgz#6001277372aec83021943157fa279ecf2b5f5cf8"
 
 debug@^2.2.0, debug@^2.6.8:
   version "2.6.9"
@@ -982,6 +982,10 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+nanoid@^1.0.7:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-1.1.0.tgz#b18e806e1cdbfdbe030374d5cf08a48cbc80b474"
+
 node-libs-browser@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.1.0.tgz#5f94263d404f6e44767d726901fff05478d600df"
@@ -1226,9 +1230,9 @@ shadow-cljs-jar@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.1.2.tgz#88664fae5957a7c21554e1a33476f1c475162c92"
 
-shadow-cljs@^2.4.16:
-  version "2.4.16"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.4.16.tgz#e017ac957eef9dc8dea333e0ed52a0d9d3287449"
+shadow-cljs@^2.4.20:
+  version "2.4.20"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.4.20.tgz#c4affd057c41a07d95415c5a2b4cc039961406ae"
   dependencies:
     babel-core "^6.26.0"
     babel-preset-env "^1.6.0"
@@ -1240,9 +1244,11 @@ shadow-cljs@^2.4.16:
     source-map-support "^0.4.15"
     ws "^3.0.0"
 
-shortid@^2.2.6:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.8.tgz#033b117d6a2e975804f6f0969dbe7d3d0b355131"
+shortid@^2.2.12:
+  version "2.2.12"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.12.tgz#8e9a95ffbc671fff8f09e985dbc7874102b0cfd2"
+  dependencies:
+    nanoid "^1.0.7"
 
 signal-exit@^3.0.2:
   version "3.0.2"
@@ -1377,9 +1383,9 @@ ws@^3.0.0:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-ws@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.1.tgz#37827a0ba772d072a843c3615b0ad38bcdb354eb"
+ws@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
Now woodenlist uses a centered layout, looks cleaner. When open done tasks, only tasks in a month will be displayed. 200+ tasks is too much for network transferring.